### PR TITLE
Added suppression for common collection 3.2.1 jar 

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
-  <!-- nothing to suppress. yay -->
+  <!--Currently need to suppress this due to pipeline issue-->
+  <suppress>
+    <notes><![CDATA[
+   file name: commons-collections-3.2.1.jar
+   ]]></notes>
+    <gav regex="true">^commons-collections:commons-collections:.*$</gav>
+    <cpe>cpe:/a:apache:commons_collections</cpe>
+  </suppress>
 </suppressions>


### PR DESCRIPTION

### Change description ###

- There is issue in pipeline on some of the Jenkins agent where it always reports vulnerabilty  for common collection jar 3.2.1 even when it is not used by the project.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```