### PR TITLE
@SSCS-2677: adding basic overnight pipeline which will test dependencies

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -1,0 +1,16 @@
+#!groovy
+
+properties([
+  // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
+  pipelineTriggers([cron('H 22 * * *')])
+])
+
+@Library("Infrastructure")
+
+def type = "java"
+def product = "sscs"
+def component = "bulk-scan"
+
+withNightlyPipeline(type, product, component) {
+  enableSlackNotifications('#sscs-bulk-scanning')
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-2677

### Change description ###

This changes adds a simple Jenkinsfile_nightly config which will automatically run the OWASP dependency checker, and results will be posted on Slack if the build fails ([or once it starts passing again](https://github.com/hmcts/cnp-jenkins-library/blob/5f476062bad590d081a9abe2755063d226f53421/README.md)).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
