### PR TITLE
@SSCS-2677: nightly pipeline to notify '#sscs-tech' slack channel

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -12,5 +12,5 @@ def product = "sscs"
 def component = "bulk-scan"
 
 withNightlyPipeline(type, product, component) {
-  enableSlackNotifications('#sscs-bulk-scanning')
+  enableSlackNotifications('#sscs-tech')
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-2677

### Change description ###

This change is to send overnight pipeline notifications to the dedicated "#sscs-tech" Slack channel to keep it consistent across `Jenkinsfile`'s and other SSCS services.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
