### PR TITLE
Added wiremock integration tests for case data helper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,8 @@ def versions = [
   reformLogging: '3.0.1',
   springBoot: springBoot.class.package.implementationVersion,
   springfoxSwagger: '2.9.2',
-  lombok: '1.18.2'
+  lombok: '1.18.2',
+  springCloudWiremock: '2.0.1.RELEASE'
 ]
 
 dependencies {
@@ -162,6 +163,8 @@ dependencies {
   compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
+
+  integrationTestCompile group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: versions.springCloudWiremock
 
   integrationTestCompile sourceSets.main.runtimeClasspath
   integrationTestCompile sourceSets.test.runtimeClasspath

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,4 +8,18 @@
     <gav regex="true">^commons-collections:commons-collections:.*$</gav>
     <cpe>cpe:/a:apache:commons_collections</cpe>
   </suppress>
+  <!-- this is for the TEST jar wiremock-standalone -->
+  <suppress>
+    <notes><![CDATA[
+       file name: wiremock-standalone-2..0.jar.
+       This is only used for TESTING purposes.
+   ]]></notes>
+    <filePath regex="true">.*wiremock-standalone-.*\.jar.*</filePath>
+    <cve>CVE-2017-7656</cve>
+    <cve>CVE-2017-7657</cve>
+    <cve>CVE-2017-7658</cve>
+    <cve>CVE-2017-9735</cve>
+    <cve>CVE-2018-5968</cve>
+    <cve>CVE-2018-7489</cve>
+  </suppress>
 </suppressions>

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscs/bulkscancore/ccd/CaseDataHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscs/bulkscancore/ccd/CaseDataHelperTest.java
@@ -1,0 +1,246 @@
+package uk.gov.hmcts.reform.sscs.bulkscancore.ccd;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.google.common.io.Resources.getResource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.ThrowableAssert.catchThrowable;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import feign.FeignException;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
+import org.apache.commons.codec.Charsets;
+import org.assertj.core.util.Strings;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.WireMockSpring;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "core_case_data.api.url=http://localhost:4000"
+    })
+@ContextConfiguration
+@DirtiesContext
+public class CaseDataHelperTest {
+
+    private static final String AUTHORIZATION_HEADER_KEY = "Authorization";
+
+    private static final String SERVICE_AUTHORIZATION_HEADER_KEY = "ServiceAuthorization";
+
+    private static final String USER_AUTH_TOKEN = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJhOGdyMjR2NmtiYXRibXFlcWthM3VuamVicSIsInN1YiI6I"
+        + "jYwIiwiaWF0IjoxNTA2NDE0OTI0LCJleHAiOjE1MDY0NDM3MjQsImRhdGEiOiJjaXRpemVuLGRpdm9yY2UtcHJpdmF0ZS1iZXRhLGNpdGl"
+        + "6ZW4tbG9hMSxkaXZvcmNlLXByaXZhdGUtYmV0YS1sb2ExIiwidHlwZSI6IkFDQ0VTUyIsImlkIjoiNjAiLCJmb3JlbmFtZSI6ImpvaG4iL"
+        + "CJzdXJuYW1lIjoic21pdGgiLCJkZWZhdWx0LXNlcnZpY2UiOiJEaXZvcmNlIiwibG9hIjoxLCJkZWZhdWx0LXVybCI6Imh0dHBzOi8vd3d"
+        + "3LWxvY2FsLnJlZ2lzdHJhdGlvbi5yZWZvcm0uaG1jdHMubmV0OjkwMDAvcG9jL2Rpdm9yY2UiLCJncm91cCI6ImRpdm9yY2UtcHJpdmF0Z"
+        + "S1iZXRhIn0.mkKaw1_CGwC7KuntMlp8SWsLLgrCFwKtr0oFmFq42AA";
+
+    private static final String SERVICE_AUTH_TOKEN = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJkaXZvcmNlX2NjZF9zdWJtaXNzaW9uIiwiZXh"
+        + "wIjoxNTA2NDUwNTUyfQ.IvB5-Rtywc9_pDlLkk3wMnWFT5ACu9FU2av4Z4xjCi7NRuDlvLy78TIDC2KzIVSqyJL4IklHOUPG7FCBT3SoIQ";
+
+    private static final String USER_ID = "1234";
+
+    private static final String INVALID_USER_TOKEN = "INVALID_USER_TOKEN";
+
+    private static final String INVALID_SERVICE_TOKEN = "INVALID_SERVICE_TOKEN";
+
+    private static final String START_EVENT_URL =
+        "/caseworkers/1234/jurisdictions/SSCS/case-types/Benefit/event-triggers/appealCreated/token";
+
+    @ClassRule
+    public static WireMockClassRule ccdServer = new WireMockClassRule(WireMockSpring.options().port(4000)
+        .bindAddress("localhost"));
+
+    @Autowired
+    private CaseDataHelper caseDataHelper;
+
+
+    @Test
+    public void should_successfully_create_case_and_return_case_data() throws Exception {
+        startForCaseworkerStub();
+
+        submitForCaseworkerStub();
+
+        Long caseId = caseDataHelper.createCase(
+            sscsCaseData(),
+            USER_AUTH_TOKEN,
+            SERVICE_AUTH_TOKEN,
+            USER_ID
+        );
+
+        assertThat(caseId).isEqualTo(Long.valueOf("1539878003972756"));
+    }
+
+    @Test
+    public void should_return_403_forbidden_response_when_user_auth_token_is_invalid() throws Exception {
+        startForCaseworkerStubWithInvalidUserToken();
+
+        Throwable exception = catchThrowable(() -> caseDataHelper.createCase(
+            sscsCaseData(),
+            INVALID_USER_TOKEN,
+            SERVICE_AUTH_TOKEN,
+            USER_ID
+        ));
+
+        assertThat(exception).isInstanceOf(FeignException.class);
+
+        assertThat(exception).hasStackTraceContaining(" \"status\": 403");
+        assertThat(exception).hasStackTraceContaining("\"message\": \"Access Denied\"");
+
+        assertThat(exception)
+            .hasStackTraceContaining("\"path\": \"/caseworkers/1234/jurisdictions/SSCS/case-types/Benefit/event-triggers/appealCreated/token\"");
+    }
+
+    @Test
+    public void should_return_403_forbidden_response_when_service_auth_token_is_invalid() throws Exception {
+        startForCaseworkerStubWithInvalidServiceToken();
+
+        Throwable exception = catchThrowable(() -> caseDataHelper.createCase(
+            sscsCaseData(),
+            USER_AUTH_TOKEN,
+            INVALID_SERVICE_TOKEN,
+            USER_ID
+        ));
+
+        assertThat(exception).isInstanceOf(FeignException.class);
+
+        assertThat(exception).hasStackTraceContaining(" \"status\": 403");
+        assertThat(exception).hasStackTraceContaining("\"message\": \"Access Denied\"");
+
+        assertThat(exception)
+            .hasStackTraceContaining("\"path\": \"/caseworkers/1234/jurisdictions/SSCS/case-types/Benefit/event-triggers/appealCreated/token\"");
+    }
+
+    @Test
+    public void should_return_404_field_not_found_when_submitting_case_data_with_invalid_fields() throws Exception {
+        startForCaseworkerStub();
+
+        submitForCaseworkerStubWithInvalidFields();
+
+        Throwable exception = catchThrowable(() -> caseDataHelper.createCase(
+            sscsCaseDataWithInvalidFields(),
+            USER_AUTH_TOKEN,
+            SERVICE_AUTH_TOKEN,
+            USER_ID
+        ));
+
+        assertThat(exception).isInstanceOf(FeignException.class);
+
+        assertThat(exception).hasStackTraceContaining(" \"status\": 404");
+        assertThat(exception).hasStackTraceContaining("\"message\": \"No field found\"");
+
+        assertThat(exception)
+            .hasStackTraceContaining("\"path\": \"/caseworkers/25/jurisdictions/SSCS/case-types/Benefit/cases\"");
+    }
+
+    private void startForCaseworkerStub() throws Exception {
+        String eventStartResponseBody = loadJson("wiremockstubs/ccd/event-start-200-response.json");
+
+        String startEventUrl = "/caseworkers/1234/jurisdictions/SSCS/case-types/Benefit/event-triggers/appealCreated/token";
+
+        ccdServer.stubFor(get(Strings.concat(startEventUrl))
+            .withHeader(AUTHORIZATION_HEADER_KEY, equalTo(USER_AUTH_TOKEN))
+            .withHeader(SERVICE_AUTHORIZATION_HEADER_KEY, equalTo(SERVICE_AUTH_TOKEN))
+            .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON_VALUE))
+            .willReturn(aResponse()
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                .withStatus(200)
+                .withBody(eventStartResponseBody)));
+    }
+
+    private void startForCaseworkerStubWithInvalidUserToken() throws Exception {
+        String eventStartResponseBody = loadJson("wiremockstubs/ccd/event-start-403-response.json");
+
+        ccdServer.stubFor(get(Strings.concat(START_EVENT_URL))
+            .withHeader(AUTHORIZATION_HEADER_KEY, equalTo(INVALID_USER_TOKEN))
+            .withHeader(SERVICE_AUTHORIZATION_HEADER_KEY, equalTo(SERVICE_AUTH_TOKEN))
+            .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON_VALUE))
+            .willReturn(aResponse()
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                .withStatus(403)
+                .withBody(eventStartResponseBody)));
+    }
+
+    private void startForCaseworkerStubWithInvalidServiceToken() throws Exception {
+        String eventStartResponseBody = loadJson("wiremockstubs/ccd/event-start-403-response.json");
+
+        ccdServer.stubFor(get(Strings.concat(START_EVENT_URL))
+            .withHeader(AUTHORIZATION_HEADER_KEY, equalTo(USER_AUTH_TOKEN))
+            .withHeader(SERVICE_AUTHORIZATION_HEADER_KEY, equalTo(INVALID_SERVICE_TOKEN))
+            .withHeader(CONTENT_TYPE, equalTo(APPLICATION_JSON_VALUE))
+            .willReturn(aResponse()
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                .withStatus(403)
+                .withBody(eventStartResponseBody)));
+    }
+
+    private void submitForCaseworkerStub() throws Exception {
+        String createCaseRequest = loadJson("wiremockstubs/ccd/case-creation-request.json");
+
+        String startEventUrl = "/caseworkers/1234/jurisdictions/SSCS/case-types/Benefit/cases?ignore-warning=true";
+
+        ccdServer.stubFor(WireMock.post(Strings.concat(startEventUrl))
+            .withHeader(AUTHORIZATION_HEADER_KEY, equalTo(USER_AUTH_TOKEN))
+            .withHeader(SERVICE_AUTHORIZATION_HEADER_KEY, equalTo(SERVICE_AUTH_TOKEN))
+            .withHeader(CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .withRequestBody(equalToJson(createCaseRequest))
+            .willReturn(aResponse()
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                .withStatus(200)
+                .withBody(loadJson("wiremockstubs/ccd/create-case-200-response.json"))));
+    }
+
+    private void submitForCaseworkerStubWithInvalidFields() throws Exception {
+        String createCaseRequest = loadJson("wiremockstubs/ccd/case-creation-request-invalid-fields.json");
+
+        String startEventUrl = "/caseworkers/1234/jurisdictions/SSCS/case-types/Benefit/cases?ignore-warning=true";
+
+        ccdServer.stubFor(WireMock.post(Strings.concat(startEventUrl))
+            .withHeader(AUTHORIZATION_HEADER_KEY, equalTo(USER_AUTH_TOKEN))
+            .withHeader(SERVICE_AUTHORIZATION_HEADER_KEY, equalTo(SERVICE_AUTH_TOKEN))
+            .withHeader(CONTENT_TYPE, equalTo(MediaType.APPLICATION_JSON_UTF8_VALUE))
+            .withRequestBody(equalToJson(createCaseRequest))
+            .willReturn(aResponse()
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                .withStatus(404)
+                .withBody(loadJson("wiremockstubs/ccd/create-case-404-response.json"))));
+    }
+
+    public static String loadJson(String fileName) throws IOException {
+        URL url = getResource(fileName);
+        return Resources.toString(url, Charsets.toCharset("UTF-8"));
+    }
+
+    public Map<String, Object> sscsCaseData() {
+        return ImmutableMap.of(
+            "generatedEmail", "sscstest@test.com",
+            "caseReference", "123456789",
+            "caseCreated", "2018-01-11",
+            "generatedNino", "SR11111",
+            "generatedSurname", "Smith"
+        );
+    }
+
+    public Map<String, Object> sscsCaseDataWithInvalidFields() {
+        return ImmutableMap.of(
+            "generatedEmail", "sscstest@test.com",
+            "caseReference1", "123456789",
+            "caseCreated", "2018-01-11",
+            "generatedNino", "SR11111",
+            "generatedSurname1", "Smith"
+        );
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscs/bulkscancore/ccd/CaseDataHelperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscs/bulkscancore/ccd/CaseDataHelperTest.java
@@ -41,15 +41,9 @@ public class CaseDataHelperTest {
 
     private static final String SERVICE_AUTHORIZATION_HEADER_KEY = "ServiceAuthorization";
 
-    private static final String USER_AUTH_TOKEN = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJhOGdyMjR2NmtiYXRibXFlcWthM3VuamVicSIsInN1YiI6I"
-        + "jYwIiwiaWF0IjoxNTA2NDE0OTI0LCJleHAiOjE1MDY0NDM3MjQsImRhdGEiOiJjaXRpemVuLGRpdm9yY2UtcHJpdmF0ZS1iZXRhLGNpdGl"
-        + "6ZW4tbG9hMSxkaXZvcmNlLXByaXZhdGUtYmV0YS1sb2ExIiwidHlwZSI6IkFDQ0VTUyIsImlkIjoiNjAiLCJmb3JlbmFtZSI6ImpvaG4iL"
-        + "CJzdXJuYW1lIjoic21pdGgiLCJkZWZhdWx0LXNlcnZpY2UiOiJEaXZvcmNlIiwibG9hIjoxLCJkZWZhdWx0LXVybCI6Imh0dHBzOi8vd3d"
-        + "3LWxvY2FsLnJlZ2lzdHJhdGlvbi5yZWZvcm0uaG1jdHMubmV0OjkwMDAvcG9jL2Rpdm9yY2UiLCJncm91cCI6ImRpdm9yY2UtcHJpdmF0Z"
-        + "S1iZXRhIn0.mkKaw1_CGwC7KuntMlp8SWsLLgrCFwKtr0oFmFq42AA";
+    private static final String USER_AUTH_TOKEN = "Bearer TEST_USER_AUTH_TOKEN";
 
-    private static final String SERVICE_AUTH_TOKEN = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJkaXZvcmNlX2NjZF9zdWJtaXNzaW9uIiwiZXh"
-        + "wIjoxNTA2NDUwNTUyfQ.IvB5-Rtywc9_pDlLkk3wMnWFT5ACu9FU2av4Z4xjCi7NRuDlvLy78TIDC2KzIVSqyJL4IklHOUPG7FCBT3SoIQ";
+    private static final String SERVICE_AUTH_TOKEN = "TEST_SERVICE_AUTH";
 
     private static final String USER_ID = "1234";
 

--- a/src/integrationTest/resources/exceptionrecord.json
+++ b/src/integrationTest/resources/exceptionrecord.json
@@ -1,0 +1,30 @@
+{
+  "token": null,
+  "event_id": "createNewCase",
+  "case_details": {
+    "case_data": {
+      "poBox": "SSCSPO",
+      "journeyClassification": "New Application",
+      "poBoxJurisdiction": "SSCS",
+      "scanRecords": [
+        {
+          "value": {
+            "key": "firstName",
+            "value": "John"
+          },
+          "id": "d55a7f14-92c3-4134-af78-f2aa2b201841"
+        },
+        {
+          "value": {
+            "key": "lastName",
+            "value": "Smith"
+          },
+          "id": "d55a7f14-92c3-4134-af78-f2aa2b201841"
+        }
+      ],
+      "openingDate": "2018-01-11"
+    },
+    "id": "12222",
+    "state": "ScannedRecordReceived"
+  }
+}

--- a/src/integrationTest/resources/wiremockstubs/ccd/case-creation-request-invalid-fields.json
+++ b/src/integrationTest/resources/wiremockstubs/ccd/case-creation-request-invalid-fields.json
@@ -1,5 +1,5 @@
 {
-  "event_token": "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI4c25kMm81NjJjbWZ0YjNhZGIwcXNuMWY4ZCIsInN1YiI6IjI1IiwiaWF0IjoxNTM5ODczODYxLCJldmVudC1pZCI6ImFwcGVhbENyZWF0ZWQiLCJjYXNlLXR5cGUtaWQiOiJCZW5lZml0IiwianVyaXNkaWN0aW9uLWlkIjoiU1NDUyIsImNhc2UtdmVyc2lvbiI6ImJmMjFhOWU4ZmJjNWEzODQ2ZmIwNWI0ZmEwODU5ZTA5MTdiMjIwMmYifQ.t8T25Pve2ib6_xLrxIqrT0SNu30oCnLVICqpqt21OWo",
+  "event_token": "test_event_token",
   "security_classification": "PUBLIC",
   "ignore_warning": false,
   "data": {

--- a/src/integrationTest/resources/wiremockstubs/ccd/case-creation-request-invalid-fields.json
+++ b/src/integrationTest/resources/wiremockstubs/ccd/case-creation-request-invalid-fields.json
@@ -1,0 +1,17 @@
+{
+  "event_token": "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI4c25kMm81NjJjbWZ0YjNhZGIwcXNuMWY4ZCIsInN1YiI6IjI1IiwiaWF0IjoxNTM5ODczODYxLCJldmVudC1pZCI6ImFwcGVhbENyZWF0ZWQiLCJjYXNlLXR5cGUtaWQiOiJCZW5lZml0IiwianVyaXNkaWN0aW9uLWlkIjoiU1NDUyIsImNhc2UtdmVyc2lvbiI6ImJmMjFhOWU4ZmJjNWEzODQ2ZmIwNWI0ZmEwODU5ZTA5MTdiMjIwMmYifQ.t8T25Pve2ib6_xLrxIqrT0SNu30oCnLVICqpqt21OWo",
+  "security_classification": "PUBLIC",
+  "ignore_warning": false,
+  "data": {
+    "caseReference1": "123456789",
+    "generatedSurname1": "Smith",
+    "generatedEmail": "sscstest@test.com",
+    "caseCreated": "2018-01-11",
+    "generatedNino": "SR11111"
+  },
+  "event": {
+    "id": "appealCreated",
+    "summary": null,
+    "description": "Case created from exception record"
+  }
+}

--- a/src/integrationTest/resources/wiremockstubs/ccd/case-creation-request.json
+++ b/src/integrationTest/resources/wiremockstubs/ccd/case-creation-request.json
@@ -1,0 +1,17 @@
+{
+  "event_token": "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI4c25kMm81NjJjbWZ0YjNhZGIwcXNuMWY4ZCIsInN1YiI6IjI1IiwiaWF0IjoxNTM5ODczODYxLCJldmVudC1pZCI6ImFwcGVhbENyZWF0ZWQiLCJjYXNlLXR5cGUtaWQiOiJCZW5lZml0IiwianVyaXNkaWN0aW9uLWlkIjoiU1NDUyIsImNhc2UtdmVyc2lvbiI6ImJmMjFhOWU4ZmJjNWEzODQ2ZmIwNWI0ZmEwODU5ZTA5MTdiMjIwMmYifQ.t8T25Pve2ib6_xLrxIqrT0SNu30oCnLVICqpqt21OWo",
+  "security_classification": "PUBLIC",
+  "ignore_warning": false,
+  "data": {
+    "caseReference": "123456789",
+    "generatedSurname": "Smith",
+    "generatedEmail": "sscstest@test.com",
+    "caseCreated": "2018-01-11",
+    "generatedNino": "SR11111"
+  },
+  "event": {
+    "id": "appealCreated",
+    "summary": null,
+    "description": "Case created from exception record"
+  }
+}

--- a/src/integrationTest/resources/wiremockstubs/ccd/case-creation-request.json
+++ b/src/integrationTest/resources/wiremockstubs/ccd/case-creation-request.json
@@ -1,5 +1,5 @@
 {
-  "event_token": "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI4c25kMm81NjJjbWZ0YjNhZGIwcXNuMWY4ZCIsInN1YiI6IjI1IiwiaWF0IjoxNTM5ODczODYxLCJldmVudC1pZCI6ImFwcGVhbENyZWF0ZWQiLCJjYXNlLXR5cGUtaWQiOiJCZW5lZml0IiwianVyaXNkaWN0aW9uLWlkIjoiU1NDUyIsImNhc2UtdmVyc2lvbiI6ImJmMjFhOWU4ZmJjNWEzODQ2ZmIwNWI0ZmEwODU5ZTA5MTdiMjIwMmYifQ.t8T25Pve2ib6_xLrxIqrT0SNu30oCnLVICqpqt21OWo",
+  "event_token": "test_event_token",
   "security_classification": "PUBLIC",
   "ignore_warning": false,
   "data": {

--- a/src/integrationTest/resources/wiremockstubs/ccd/create-case-200-response.json
+++ b/src/integrationTest/resources/wiremockstubs/ccd/create-case-200-response.json
@@ -1,0 +1,31 @@
+{
+  "id": 1539878003972756,
+  "jurisdiction": "SSCS",
+  "state": "appealCreated",
+  "case_type_id": "Benefit",
+  "created_date": "2018-10-18T15:53:23.974",
+  "last_modified": "2018-10-18T15:53:23.978",
+  "security_classification": "PUBLIC",
+  "case_data": {
+    "caseReference": "123456789",
+    "generatedSurname": "Smith",
+    "generatedEmail": "sscstest@test.com",
+    "caseCreated" : "2018-01-11",
+    "generatedNino" :"SR11111"
+  },
+  "data_classification": {
+    "caseReference": "PUBLIC",
+    "generatedSurname": "PUBLIC",
+    "generatedEmail": "PUBLIC",
+    "caseCreated" : "PUBLIC",
+    "generatedNino" :"PUBLIC"
+  },
+  "after_submit_callback_response": null,
+  "callback_response_status_code": 200,
+  "callback_response_status": "INCOMPLETE",
+  "security_classifications": {
+    "caseReference": "PUBLIC",
+    "generatedSurname": "PUBLIC",
+    "generatedEmail": "PUBLIC"
+  }
+}

--- a/src/integrationTest/resources/wiremockstubs/ccd/create-case-404-response.json
+++ b/src/integrationTest/resources/wiremockstubs/ccd/create-case-404-response.json
@@ -1,0 +1,11 @@
+{
+  "exception": "uk.gov.hmcts.ccd.endpoint.exceptions.ResourceNotFoundException",
+  "timestamp": "2018-10-19T12:37:06.61",
+  "status": 404,
+  "error": "Not Found",
+  "message": "No field found",
+  "path": "/caseworkers/25/jurisdictions/SSCS/case-types/Benefit/cases",
+  "details": null,
+  "callbackErrors": null,
+  "callbackWarnings": null
+}

--- a/src/integrationTest/resources/wiremockstubs/ccd/event-start-200-response.json
+++ b/src/integrationTest/resources/wiremockstubs/ccd/event-start-200-response.json
@@ -1,5 +1,5 @@
 {
-  "token": "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI4c25kMm81NjJjbWZ0YjNhZGIwcXNuMWY4ZCIsInN1YiI6IjI1IiwiaWF0IjoxNTM5ODczODYxLCJldmVudC1pZCI6ImFwcGVhbENyZWF0ZWQiLCJjYXNlLXR5cGUtaWQiOiJCZW5lZml0IiwianVyaXNkaWN0aW9uLWlkIjoiU1NDUyIsImNhc2UtdmVyc2lvbiI6ImJmMjFhOWU4ZmJjNWEzODQ2ZmIwNWI0ZmEwODU5ZTA5MTdiMjIwMmYifQ.t8T25Pve2ib6_xLrxIqrT0SNu30oCnLVICqpqt21OWo",
+  "token": "test_event_token",
   "case_details": {
     "id": null,
     "jurisdiction": "SSCS",

--- a/src/integrationTest/resources/wiremockstubs/ccd/event-start-200-response.json
+++ b/src/integrationTest/resources/wiremockstubs/ccd/event-start-200-response.json
@@ -1,0 +1,19 @@
+{
+  "token": "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI4c25kMm81NjJjbWZ0YjNhZGIwcXNuMWY4ZCIsInN1YiI6IjI1IiwiaWF0IjoxNTM5ODczODYxLCJldmVudC1pZCI6ImFwcGVhbENyZWF0ZWQiLCJjYXNlLXR5cGUtaWQiOiJCZW5lZml0IiwianVyaXNkaWN0aW9uLWlkIjoiU1NDUyIsImNhc2UtdmVyc2lvbiI6ImJmMjFhOWU4ZmJjNWEzODQ2ZmIwNWI0ZmEwODU5ZTA5MTdiMjIwMmYifQ.t8T25Pve2ib6_xLrxIqrT0SNu30oCnLVICqpqt21OWo",
+  "case_details": {
+    "id": null,
+    "jurisdiction": "SSCS",
+    "state": null,
+    "case_type_id": "Benefit",
+    "created_date": null,
+    "last_modified": null,
+    "security_classification": null,
+    "case_data": {},
+    "data_classification": {},
+    "after_submit_callback_response": null,
+    "callback_response_status_code": null,
+    "callback_response_status": null,
+    "security_classifications": {}
+  },
+  "event_id": "appealCreated"
+}

--- a/src/integrationTest/resources/wiremockstubs/ccd/event-start-403-response.json
+++ b/src/integrationTest/resources/wiremockstubs/ccd/event-start-403-response.json
@@ -1,0 +1,7 @@
+{
+  "timestamp": "2018-10-19T09:32:06.430+0000",
+  "status": 403,
+  "error": "Forbidden",
+  "message": "Access Denied",
+  "path": "/caseworkers/1234/jurisdictions/SSCS/case-types/Benefit/event-triggers/appealCreated/token"
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/bulkscancore/ccd/CaseDataHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/bulkscancore/ccd/CaseDataHelper.java
@@ -4,10 +4,7 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
-import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
-import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.ccd.client.model.Event;
-import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
+import uk.gov.hmcts.reform.ccd.client.model.*;
 
 @Component
 public class CaseDataHelper {
@@ -49,6 +46,7 @@ public class CaseDataHelper {
         return CaseDataContent.builder()
             .data(sscsCaseData)
             .eventToken(eventToken)
+            .securityClassification(Classification.PUBLIC)
             .event(Event.builder()
                 .description("Case created from exception record")
                 .id(eventId)

--- a/src/main/java/uk/gov/hmcts/reform/sscs/controllers/CcdCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/controllers/CcdCallbackController.java
@@ -45,5 +45,4 @@ public class CcdCallbackController {
 
         return ResponseEntity.ok(ccdCallbackResponse);
     }
-
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,4 +19,3 @@ ccd:
 core_case_data:
   api:
     url: http://localhost:4452
-

--- a/src/test/java/uk/gov/hmcts/reform/sscs/bulkscancore/ccd/CaseDataHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/bulkscancore/ccd/CaseDataHelperTest.java
@@ -20,11 +20,7 @@ import uk.gov.hmcts.reform.sscs.common.SampleCaseDataCreator;
 @RunWith(SpringRunner.class)
 public class CaseDataHelperTest {
 
-    private static final String EVENT_TOKEN =
-        "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI4cG1jN284YWdyaDA0MzIxcGJ1ZG5rOGs1cCIsInN1YiI6IjI1IiwiaWF0IjoxNTM4OTk2MTQyLCJldm"
-            + "VudC1pZCI6ImFwcGVhbENyZWF0ZWQiLCJjYXNlLXR5cGUtaWQiOiJCZW5lZml0IiwianVyaXNkaWN0aW9uLWlkIjoiU1NDUyIsImNhc2U"
-            + "tdmVyc2lvbiI6ImJmMjFhOWU4ZmJjNWEzODQ2ZmIwNWI0ZmEwODU5ZTA5MTdiMjIwMmYifQ.v5CIHOFPKCrxjhEKAPDhltd-ErynobIY5"
-            + "FVjXJffEVU";
+    private static final String EVENT_TOKEN = "VALID_EVENT_TOKEN";
 
     private static final Long CASE_ID = Long.valueOf("1538992487551266");
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/bulkscancore/ccd/CaseDataHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/bulkscancore/ccd/CaseDataHelperTest.java
@@ -14,10 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.HttpServerErrorException;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
-import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
-import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.ccd.client.model.Event;
-import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
+import uk.gov.hmcts.reform.ccd.client.model.*;
 import uk.gov.hmcts.reform.sscs.common.SampleCaseDataCreator;
 
 @RunWith(SpringRunner.class)
@@ -72,6 +69,7 @@ public class CaseDataHelperTest {
             sscsCaseDataContent())
         ).thenReturn(CaseDetails.builder()
             .id(CASE_ID)
+            .securityClassification(Classification.PUBLIC)
             .data(caseDataCreator.sscsCaseData())
             .createdDate(LocalDateTime.of(2018, 1, 1, 0, 0))
             .build());
@@ -123,6 +121,7 @@ public class CaseDataHelperTest {
                 .id("appealCreated")
                 .build()
             )
+            .securityClassification(Classification.PUBLIC)
             .build();
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-744

### Change description ###

- Added Wiremock integration tests for case data helper.

- Once transformation and validation are in place we can add more integration tests including controller -> Handler ->Transform->Validate->CCD

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```