### PR TITLE
SSCS-4394 Populate generated fields

### DIFF
--- a/src/integrationTest/resources/mappings/case-creation-request.json
+++ b/src/integrationTest/resources/mappings/case-creation-request.json
@@ -74,7 +74,10 @@
           "document_filename" : "myfile.jpg"
         }
       }
-    } ]
+    } ],
+    "generatedNino" : "JT0123456B",
+    "generatedSurname" : "Smith",
+    "generatedDOB" : "1976-11-11"
   },
   "security_classification" : "PUBLIC",
   "event_token" : "test_event_token",

--- a/src/integrationTest/resources/mappings/case-incomplete-creation-request.json
+++ b/src/integrationTest/resources/mappings/case-incomplete-creation-request.json
@@ -51,7 +51,10 @@
       "signer": null,
       "hearingType": "oral"
     },
-    "sscsDocument" : [ ]
+    "sscsDocument" : [ ],
+    "generatedNino" : null,
+    "generatedSurname" : null,
+    "generatedDOB" : null
   },
   "security_classification" : "PUBLIC",
   "event_token" : "test_event_token",

--- a/src/integrationTest/resources/mappings/case-non-compliant-creation-request.json
+++ b/src/integrationTest/resources/mappings/case-non-compliant-creation-request.json
@@ -74,7 +74,10 @@
           "document_filename" : "myfile.jpg"
         }
       }
-    } ]
+    } ],
+    "generatedNino" : "JT0123456B",
+    "generatedSurname" : "Smith",
+    "generatedDOB" : "1976-11-11"
   },
   "security_classification" : "PUBLIC",
   "event_token" : "test_event_token",

--- a/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
@@ -38,12 +38,18 @@ public class SscsCaseTransformer implements CaseTransformer {
 
         errors = new ArrayList<>();
 
-        ScannedData sscsData = sscsJsonExtractor.extractJson(caseData);
-        Appeal appeal = buildAppealFromData(sscsData.getOcrCaseData());
-        List<SscsDocument> sscsDocuments = buildDocumentsFromData(sscsData.getRecords());
+        ScannedData scannedData = sscsJsonExtractor.extractJson(caseData);
+        Appeal appeal = buildAppealFromData(scannedData.getOcrCaseData());
+        List<SscsDocument> sscsDocuments = buildDocumentsFromData(scannedData.getRecords());
 
         transformed.put("appeal", appeal);
         transformed.put("sscsDocument", sscsDocuments);
+
+        if (appeal.getAppellant() != null) {
+            transformed.put("generatedNino", appeal.getAppellant().getIdentity().getNino());
+            transformed.put("generatedSurname", appeal.getAppellant().getName().getLastName());
+            transformed.put("generatedDOB", appeal.getAppellant().getIdentity().getDob());
+        }
 
         return CaseResponse.builder().transformedCase(transformed).errors(errors).build();
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
@@ -549,6 +549,42 @@ public class SscsCaseTransformerTest {
         assertTrue(result.getErrors().isEmpty());
     }
 
+    @Test
+    public void givenAnAppellantDateOfBirth_thenSetGeneratedDobField() {
+        pairs.put("person1_dob", "12/01/1987");
+
+        CaseResponse result = transformer.transformExceptionRecordToCase(ocrMap);
+
+        String generatedDob = ((String) result.getTransformedCase().get("generatedDOB"));
+        assertEquals("1987-01-12", generatedDob);
+
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    public void givenAnAppellantSurname_thenSetGeneratedSurnameField() {
+        pairs.put("person1_last_name", "Smith");
+
+        CaseResponse result = transformer.transformExceptionRecordToCase(ocrMap);
+
+        String generatedSurname = ((String) result.getTransformedCase().get("generatedSurname"));
+        assertEquals("Smith", generatedSurname);
+
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    public void givenAnAppellantNino_thenSetGeneratedNinoField() {
+        pairs.put("person1_nino", "JT0123456B");
+
+        CaseResponse result = transformer.transformExceptionRecordToCase(ocrMap);
+
+        String generatedNino = ((String) result.getTransformedCase().get("generatedNino"));
+        assertEquals("JT0123456B", generatedNino);
+
+        assertTrue(result.getErrors().isEmpty());
+    }
+
     private Appeal buildTestAppealData() {
         Name appellantName = Name.builder().title(APPELLANT_TITLE).firstName(APPELLANT_FIRST_NAME).lastName(APPELLANT_LAST_NAME).build();
         Address appellantAddress = Address.builder().line1(APPELLANT_ADDRESS_LINE1).line2(APPELLANT_ADDRESS_LINE2).town(APPELLANT_ADDRESS_LINE3).county(APPELLANT_ADDRESS_LINE4).postcode(APPELLANT_POSTCODE).build();


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-4394

### Change description ###
- Populate the generatedNino, generatedSurname and generatedDOB fields when transforming the case
- This enables SSCS cases to be searched in CCD


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```