### PR TITLE
Add test data import script

### DIFF
--- a/bin/create-test-data.sh
+++ b/bin/create-test-data.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+## Usage: ./create-test-data.sh
+##
+## Creates test data in CCD using the /exception-record endpoint
+
+binFolder=$(dirname "$0")
+
+userId=1
+userToken="$(${binFolder}/idam-user-token.sh caseworker-sscs,caseworker-sscs-systemupdate,caseworker-sscs-anonymouscitizen,caseworker-sscs-callagent,caseworker $userId)"
+serviceToken="$(${binFolder}/idam-service-token.sh ccd_data)"
+
+for f in ../build/resources/test/import/*.json
+do
+  echo "Importing ${f}"
+  curl \
+    http://localhost:8090/exception-record \
+    -H "Authorization: Bearer ${userToken}" \
+    -H "ServiceAuthorization: Bearer ${serviceToken}" \
+    -H "user-id: ${userId}" \
+    -H "Content-Type: application/json" \
+    --data @$f
+done
+
+

--- a/bin/idam-service-token.sh
+++ b/bin/idam-service-token.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+## Usage: ./idam-service-token.sh [microservice_name]
+##
+## Options:
+##    - microservice_name: Name of the microservice. Default to `ccd_gw`.
+##
+## Returns a valid IDAM service token for the given microservice.
+
+microservice="${1:-ccd_gw}"
+
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"microservice":"'${microservice}'"}' \
+  http://localhost:4502/testing-support/lease

--- a/bin/idam-user-token.sh
+++ b/bin/idam-user-token.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+## Usage: ./idam-user-token.sh [role] [user_id]
+##
+## Options:
+##    - role: Role assigned to user in generated token. Default to `ccd-import`.
+##    - user_id: ID assigned to user in generated token. Default to `1`.
+##
+## Returns a valid IDAM user token for the given role and user_id.
+
+ROLE="${1:-ccd-import}"
+USER_ID="${2:-1}"
+
+curl --silent http://localhost:4501/testing-support/lease -Fid="${USER_ID}" -Frole="${ROLE}"


### PR DESCRIPTION
By running ./bin/import-test-data.sh, all JSON files in the build/resources/test/import folder will be injested via the exception-record endpoint.