### PR TITLE
Allow empty excluded dates field

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -30,6 +30,10 @@
     <cve>CVE-2018-10237</cve>
   </suppress>
   <suppress>
+    <notes><![CDATA[ slf4j ]]></notes>
+    <cve>CVE-2018-8088</cve>
+  </suppress>
+  <suppress>
     <notes><![CDATA[
    file name: groovy-xml-2.4.15.jar
    ]]></notes>

--- a/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
@@ -251,22 +251,24 @@ public class SscsCaseTransformer implements CaseTransformer {
         List<ExcludeDate> excludeDates = new ArrayList<>();
         List<String> items = Arrays.asList(excludedDatesList.split(",\\s*"));
 
-        for (String item : items) {
-            List<String> range = Arrays.asList(item.split("\\s*-\\s*"));
-            String errorMessage = "hearing_options_exclude_dates contains an invalid date range. Should be single dates separated by commas and/or a date range e.g. 01/01/2019, 07/01/2019, 12/01/2019 - 15/01/2019";
+        if (!excludedDatesList.isEmpty()) {
+            for (String item : items) {
+                List<String> range = Arrays.asList(item.split("\\s*-\\s*"));
+                String errorMessage = "hearing_options_exclude_dates contains an invalid date range. Should be single dates separated by commas and/or a date range e.g. 01/01/2019, 07/01/2019, 12/01/2019 - 15/01/2019";
 
-            if (range.size() > 2) {
-                errors.add(errorMessage);
-                return excludeDates;
+                if (range.size() > 2) {
+                    errors.add(errorMessage);
+                    return excludeDates;
+                }
+
+                String startDate = getDateForCcd(range.get(0), errors, errorMessage);
+                String endDate = null;
+
+                if (2 == range.size()) {
+                    endDate = getDateForCcd(range.get(1), errors, errorMessage);
+                }
+                excludeDates.add(ExcludeDate.builder().value(DateRange.builder().start(startDate).end(endDate).build()).build());
             }
-
-            String startDate = getDateForCcd(range.get(0), errors, errorMessage);
-            String endDate = null;
-
-            if (2 == range.size()) {
-                endDate = getDateForCcd(range.get(1), errors, errorMessage);
-            }
-            excludeDates.add(ExcludeDate.builder().value(DateRange.builder().start(startDate).end(endDate).build()).build());
         }
         return excludeDates;
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
@@ -249,9 +249,10 @@ public class SscsCaseTransformer implements CaseTransformer {
 
     private List<ExcludeDate> extractExcludedDates(String excludedDatesList) {
         List<ExcludeDate> excludeDates = new ArrayList<>();
-        List<String> items = Arrays.asList(excludedDatesList.split(",\\s*"));
 
-        if (!excludedDatesList.isEmpty()) {
+        if (excludedDatesList != null && !excludedDatesList.isEmpty()) {
+            List<String> items = Arrays.asList(excludedDatesList.split(",\\s*"));
+
             for (String item : items) {
                 List<String> range = Arrays.asList(item.split("\\s*-\\s*"));
                 String errorMessage = "hearing_options_exclude_dates contains an invalid date range. Should be single dates separated by commas and/or a date range e.g. 01/01/2019, 07/01/2019, 12/01/2019 - 15/01/2019";

--- a/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static uk.gov.hmcts.reform.sscs.TestDataConstants.*;
-import static uk.gov.hmcts.reform.sscs.TestDataConstants.MRN_DATE;
 import static uk.gov.hmcts.reform.sscs.constants.SscsConstants.*;
 
 import com.google.common.collect.ImmutableList;
@@ -356,6 +355,19 @@ public class SscsCaseTransformerTest {
 
         assertTrue(result.getErrors().isEmpty());
     }
+
+    @Test
+    public void givenExcludedDateRangeIsEmpty_thenBuildAnAppealWithEmptyExcludedDateRange() {
+
+        pairs.put("hearing_options_exclude_dates", "");
+
+        CaseResponse result = transformer.transformExceptionRecordToCase(caseDetails);
+
+        List<ExcludeDate> excludeDates = ((Appeal) result.getTransformedCase().get("appeal")).getHearingOptions().getExcludeDates();
+
+        assertTrue(excludeDates.isEmpty());
+        assertTrue(result.getErrors().isEmpty());
+    }    
 
     @Test
     public void givenSingleExcludedDateFollowedByRangeWithSpace_thenBuildAnAppealWithSingleExcludedStartDateAndADateRange() {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static uk.gov.hmcts.reform.sscs.TestDataConstants.*;
+import static uk.gov.hmcts.reform.sscs.TestDataConstants.MRN_DATE;
 import static uk.gov.hmcts.reform.sscs.constants.SscsConstants.*;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
@@ -371,6 +371,19 @@ public class SscsCaseTransformerTest {
     }    
 
     @Test
+    public void givenExcludedDateRangeIsNull_thenBuildAnAppealWithEmptyExcludedDateRange() {
+
+        pairs.put("hearing_options_exclude_dates", null);
+
+        CaseResponse result = transformer.transformExceptionRecordToCase(caseDetails);
+
+        List<ExcludeDate> excludeDates = ((Appeal) result.getTransformedCase().get("appeal")).getHearingOptions().getExcludeDates();
+
+        assertTrue(excludeDates.isEmpty());
+        assertTrue(result.getErrors().isEmpty());
+    }    
+
+    @Test
     public void givenSingleExcludedDateFollowedByRangeWithSpace_thenBuildAnAppealWithSingleExcludedStartDateAndADateRange() {
 
         pairs.put("hearing_options_exclude_dates", "12/12/2018, 16/12/2018 - 18/12/2018");


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-4792

### Change description ###

hearing_option_exclude_dates is allowed to be empty.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
