### PR TITLE
Allow dates to be null or empty and do not add an error

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/util/SscsOcrDataUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/util/SscsOcrDataUtil.java
@@ -81,9 +81,7 @@ public final class SscsOcrDataUtil {
     public static String getDateForCcd(String ocrField, List<String> errors, String errorMessage) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 
-        if (StringUtils.isEmpty(ocrField)) {
-            errors.add(errorMessage);
-        } else {
+        if (!StringUtils.isEmpty(ocrField)) {
             try {
                 return LocalDate.parse(ocrField, formatter).toString();
             } catch (DateTimeParseException ex) {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
@@ -249,7 +249,7 @@ public class SscsCaseTransformerTest {
 
         CaseResponse result = transformer.transformExceptionRecordToCase(caseDetails);
 
-        assertTrue(result.getErrors().contains("mrn_date is an invalid date field. Needs to be in the format dd/mm/yyyy"));
+        assertTrue(result.getErrors().isEmpty());
     }
 
     @Test
@@ -258,7 +258,7 @@ public class SscsCaseTransformerTest {
 
         CaseResponse result = transformer.transformExceptionRecordToCase(caseDetails);
 
-        assertTrue(result.getErrors().contains("mrn_date is an invalid date field. Needs to be in the format dd/mm/yyyy"));
+        assertTrue(result.getErrors().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
