### PR TITLE
SSCS-4822 Fix for no leading zero date bug

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/util/SscsOcrDataUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/util/SscsOcrDataUtil.java
@@ -79,7 +79,7 @@ public final class SscsOcrDataUtil {
     }
 
     public static String getDateForCcd(String ocrField, List<String> errors, String errorMessage) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d/M/yyyy");
 
         if (!StringUtils.isEmpty(ocrField)) {
             try {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/util/SscsOcrDataUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/util/SscsOcrDataUtilTest.java
@@ -210,6 +210,13 @@ public class SscsOcrDataUtilTest {
     }
 
     @Test
+    public void givenAnOcrDateWithNoLeadingZero_thenConvertToCcdDateFormat() {
+        pairs.put("hearingDate", "1/1/2018");
+
+        assertEquals("2018-01-01", generateDateForCcd(pairs, new ArrayList<>(), "hearingDate"));
+    }
+
+    @Test
     public void givenAnOcrDateWithInvalidFormat_thenAddError() {
         pairs.put("hearingDate", "01/30/2018");
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-4822


### Change description ###
- When dates have no leading zero they are now converted to a date field with no warning shown


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```