### PR TITLE
SSCS-4823 Case creation date empty

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/bulkscancore/handlers/CcdCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/bulkscancore/handlers/CcdCallbackHandler.java
@@ -100,7 +100,7 @@ public class CcdCallbackHandler {
 
             return AboutToStartOrSubmitCallbackResponse.builder()
                 .warnings(caseValidationResponse.getWarnings())
-                .data(appealData).build();
+                .build();
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/bulkscan/CcdCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/bulkscan/CcdCallbackHandlerTest.java
@@ -148,7 +148,7 @@ public class CcdCallbackHandlerTest {
     }
 
     @Test
-    public void should_return_sscs_data_with_case_id_and_state_when_validation_endpoint_is_successful() {
+    public void should_return_no_warnings_or_errors_or_data_when_validation_endpoint_is_successful() {
 
         Appeal appeal = Appeal.builder()
             .appellant(Appellant.builder()
@@ -170,14 +170,7 @@ public class CcdCallbackHandlerTest {
         AboutToStartOrSubmitCallbackResponse ccdCallbackResponse =
             (AboutToStartOrSubmitCallbackResponse) invokeValidationCallbackHandler(caseDetails);
 
-        assertThat(ccdCallbackResponse.getData()).contains(
-            entry("generatedSurname", "Ward"),
-            entry("generatedNino", "JT123456N"),
-            entry("generatedDOB", "12/08/1990"),
-            entry("evidencePresent", "No"),
-            entry("appeal", appeal)
-        );
-
+        assertThat(ccdCallbackResponse.getData()).isNull();
         assertThat(ccdCallbackResponse.getErrors()).isNull();
         assertThat(ccdCallbackResponse.getWarnings()).isNull();
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-4823


### Change description ###
- When case goes from incomplete to valid appeal, the case creation date was getting overriden
- Fix to not return any data to CCD after the validate callback finishes


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```