### PR TITLE
SSCS-4901 Handle hearing type booleans

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,7 +187,7 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.127'
   compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '0.0.96'
-  compile group: 'uk.gov.hmcts.reform', name: 'sscs-robotics-common', version: '0.0.5'
+  compile group: 'uk.gov.hmcts.reform', name: 'sscs-robotics-common', version: '0.0.6'
   compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '1.0.4'
 
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.0.1.RELEASE'

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscs/controllers/SscsBulkScanValidateRecordCallback.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscs/controllers/SscsBulkScanValidateRecordCallback.java
@@ -105,7 +105,8 @@ public class SscsBulkScanValidateRecordCallback extends BaseTest {
                 "Hearing options exclude dates is in past",
                 "Mrn date is empty",
                 "DWP issuing office is empty",
-                "Benefit type description is empty");
+                "Benefit type description is empty",
+                "Hearing type is invalid");
 
         verify(authTokenValidator).getServiceName(SERVICE_AUTH_TOKEN);
     }

--- a/src/integrationTest/resources/mappings/validation/validate-appeal-created-case-request.json
+++ b/src/integrationTest/resources/mappings/validation/validate-appeal-created-case-request.json
@@ -30,6 +30,7 @@
         "benefitType": {
           "code": "ESA"
         },
+        "hearingType": "oral",
         "hearingOptions": {
           "languageInterpreter": "Yes",
           "other": "No",

--- a/src/integrationTest/resources/mappings/validation/validate-appeal-created-missing-appellant-and-appointee-request.json
+++ b/src/integrationTest/resources/mappings/validation/validate-appeal-created-missing-appellant-and-appointee-request.json
@@ -43,6 +43,7 @@
         "benefitType": {
           "code": "ESA"
         },
+        "hearingType": "oral",
         "hearingOptions": {
           "languageInterpreter": "Yes",
           "other": "No",

--- a/src/integrationTest/resources/mappings/validation/validate-appeal-created-missing-appointee-request.json
+++ b/src/integrationTest/resources/mappings/validation/validate-appeal-created-missing-appointee-request.json
@@ -47,6 +47,7 @@
         "benefitType": {
           "code": "ESA"
         },
+        "hearingType": "oral",
         "hearingOptions": {
           "languageInterpreter": "Yes",
           "other": "No",

--- a/src/integrationTest/resources/mappings/validation/validate-appeal-created-missing-representative-request.json
+++ b/src/integrationTest/resources/mappings/validation/validate-appeal-created-missing-representative-request.json
@@ -40,6 +40,7 @@
         "benefitType": {
           "code": "ESA"
         },
+        "hearingType": "oral",
         "hearingOptions": {
           "languageInterpreter": "Yes",
           "other": "No",

--- a/src/integrationTest/resources/mappings/validation/validate-interloc-appeal-created-case-request.json
+++ b/src/integrationTest/resources/mappings/validation/validate-interloc-appeal-created-case-request.json
@@ -30,6 +30,7 @@
         "benefitType": {
           "code": "ESA"
         },
+        "hearingType": "oral",
         "hearingOptions": {
           "languageInterpreter": "Yes",
           "other": "No",

--- a/src/main/java/uk/gov/hmcts/reform/sscs/constants/SscsConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/constants/SscsConstants.java
@@ -23,6 +23,7 @@ public final class SscsConstants {
     public static final String HEARING_SUPPORT_ARRANGEMENTS_LITERAL = "hearing_support_arrangements";
     public static final String DEFAULT_SIGN_LANGUAGE = "British Sign Language";
     public static final String BENEFIT_TYPE_DESCRIPTION = "benefit_type_description";
+    public static final String HEARING_TYPE_DESCRIPTION = "hearing_type";
     public static final String MRN_DATE = "mrn_date";
     public static final String ISSUING_OFFICE = "office";
     public static final String YES_LITERAL = "Yes";

--- a/src/main/java/uk/gov/hmcts/reform/sscs/constants/WarningMessage.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/constants/WarningMessage.java
@@ -35,7 +35,8 @@ public enum WarningMessage {
     APPELLANT_NINO(NINO, "Appellant nino"),
     APPELLANT_PHONE(PHONE, "Appellant phone"),
     APPELLANT_DOB(DOB, "Appellant date of birth"),
-    APPOINTEE_DOB(DOB, "Appointee date of birth");
+    APPOINTEE_DOB(DOB, "Appointee date of birth"),
+    HEARING_TYPE("is_hearing_type_oral and/or is_hearing_type_paper", "Hearing type");
 
     private String exceptionRecordMessage;
     private String validationRecordMessage;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
@@ -208,7 +208,14 @@ public class SscsCaseTransformer implements CaseTransformer {
     }
 
     private String findHearingType(Map<String, Object> pairs) {
-        if (areMandatoryBooleansValid(pairs, errors, IS_HEARING_TYPE_ORAL_LITERAL, IS_HEARING_TYPE_PAPER_LITERAL) && !doValuesContradict(pairs, errors, IS_HEARING_TYPE_ORAL_LITERAL, IS_HEARING_TYPE_PAPER_LITERAL)) {
+
+        if (checkBooleanValue(pairs, IS_HEARING_TYPE_ORAL_LITERAL) && (pairs.get(IS_HEARING_TYPE_PAPER_LITERAL) == null || pairs.get(IS_HEARING_TYPE_PAPER_LITERAL).equals("null"))) {
+            pairs.put(IS_HEARING_TYPE_PAPER_LITERAL, !Boolean.parseBoolean(pairs.get(IS_HEARING_TYPE_ORAL_LITERAL).toString()));
+        } else if (checkBooleanValue(pairs, IS_HEARING_TYPE_PAPER_LITERAL) && (pairs.get(IS_HEARING_TYPE_ORAL_LITERAL) == null || pairs.get(IS_HEARING_TYPE_ORAL_LITERAL).equals("null"))) {
+            pairs.put(IS_HEARING_TYPE_ORAL_LITERAL,!Boolean.parseBoolean(pairs.get(IS_HEARING_TYPE_PAPER_LITERAL).toString()));
+        }
+
+        if (areBooleansValid(pairs, IS_HEARING_TYPE_ORAL_LITERAL, IS_HEARING_TYPE_PAPER_LITERAL) && !doValuesContradict(pairs, errors, IS_HEARING_TYPE_ORAL_LITERAL, IS_HEARING_TYPE_PAPER_LITERAL)) {
             return Boolean.parseBoolean(pairs.get(IS_HEARING_TYPE_ORAL_LITERAL).toString()) ? HEARING_TYPE_ORAL : HEARING_TYPE_PAPER;
         }
         return null;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/util/SscsOcrDataUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/util/SscsOcrDataUtil.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.format.ResolverStyle;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -49,22 +48,11 @@ public final class SscsOcrDataUtil {
         return false;
     }
 
-    public static boolean areMandatoryBooleansValid(Map<String, Object> pairs, List<String> errors, String... values) {
-        List<String> booleanErrors = new ArrayList<>();
-        for (String value : values) {
-            if (!checkBooleanValue(pairs, value)) {
-                booleanErrors.add(value + " does not contain a valid boolean value. Needs to be true or false");
-            }
-        }
-        errors.addAll(booleanErrors);
-        return booleanErrors.isEmpty();
-    }
-
     public static boolean areBooleansValid(Map<String, Object> pairs, String... values) {
         return Stream.of(values).allMatch(value -> checkBooleanValue(pairs, value));
     }
 
-    private static boolean checkBooleanValue(Map<String, Object> pairs, String value) {
+    public static boolean checkBooleanValue(Map<String, Object> pairs, String value) {
         return pairs.get(value) != null && BooleanUtils.toBooleanObject(pairs.get(value).toString()) != null;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/validators/SscsCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/validators/SscsCaseValidator.java
@@ -64,6 +64,8 @@ public class SscsCaseValidator implements CaseValidator {
 
         isBenefitTypeValid(appeal);
 
+        isHearingTypeValid(appeal);
+
         return warnings;
     }
 
@@ -302,6 +304,14 @@ public class SscsCaseValidator implements CaseValidator {
             }
         } else {
             warnings.add(getMessageByCallbackType(callbackType, "", BENEFIT_TYPE_DESCRIPTION, IS_EMPTY));
+        }
+    }
+
+    private void isHearingTypeValid(Appeal appeal) {
+        String hearingType = appeal.getHearingType();
+
+        if (hearingType == null || (!hearingType.equals(HEARING_TYPE_ORAL) && !hearingType.equals(HEARING_TYPE_PAPER))) {
+            warnings.add(getMessageByCallbackType(callbackType, "", HEARING_TYPE_DESCRIPTION, IS_INVALID));
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
@@ -253,7 +253,59 @@ public class SscsCaseTransformerTest {
     }
 
     @Test
-    public void givenBooleanValueIsText_thenAddErrorToList() {
+    public void givenHearingTypeOralIsTrueAndHearingTypePaperIsEmpty_thenSetHearingTypeToOral() {
+        Map<String, Object> hearingTypePairs = new HashMap<>();
+        hearingTypePairs.put("is_hearing_type_oral", true);
+        hearingTypePairs.put("is_hearing_type_paper", "null");
+
+        given(sscsJsonExtractor.extractJson(ocrMap)).willReturn(ScannedData.builder().ocrCaseData(hearingTypePairs).build());
+
+        CaseResponse result = transformer.transformExceptionRecordToCase(caseDetails);
+
+        assertEquals(HEARING_TYPE_ORAL, ((Appeal) result.getTransformedCase().get("appeal")).getHearingType());
+    }
+
+    @Test
+    public void givenHearingTypePaperIsTrueAndHearingTypeOralIsEmpty_thenSetHearingTypeToPaper() {
+        Map<String, Object> hearingTypePairs = new HashMap<>();
+        hearingTypePairs.put("is_hearing_type_oral", "null");
+        hearingTypePairs.put("is_hearing_type_paper", true);
+
+        given(sscsJsonExtractor.extractJson(ocrMap)).willReturn(ScannedData.builder().ocrCaseData(hearingTypePairs).build());
+
+        CaseResponse result = transformer.transformExceptionRecordToCase(caseDetails);
+
+        assertEquals(HEARING_TYPE_PAPER, ((Appeal) result.getTransformedCase().get("appeal")).getHearingType());
+    }
+
+    @Test
+    public void givenHearingTypeOralIsFalseAndHearingTypePaperIsEmpty_thenSetHearingTypeToPaper() {
+        Map<String, Object> hearingTypePairs = new HashMap<>();
+        hearingTypePairs.put("is_hearing_type_oral", false);
+        hearingTypePairs.put("is_hearing_type_paper", "null");
+
+        given(sscsJsonExtractor.extractJson(ocrMap)).willReturn(ScannedData.builder().ocrCaseData(hearingTypePairs).build());
+
+        CaseResponse result = transformer.transformExceptionRecordToCase(caseDetails);
+
+        assertEquals(HEARING_TYPE_PAPER, ((Appeal) result.getTransformedCase().get("appeal")).getHearingType());
+    }
+
+    @Test
+    public void givenHearingTypePaperIsFalseAndHearingTypeOralIsEmpty_thenSetHearingTypeToOral() {
+        Map<String, Object> hearingTypePairs = new HashMap<>();
+        hearingTypePairs.put("is_hearing_type_oral", "null");
+        hearingTypePairs.put("is_hearing_type_paper", false);
+
+        given(sscsJsonExtractor.extractJson(ocrMap)).willReturn(ScannedData.builder().ocrCaseData(hearingTypePairs).build());
+
+        CaseResponse result = transformer.transformExceptionRecordToCase(caseDetails);
+
+        assertEquals(HEARING_TYPE_ORAL, ((Appeal) result.getTransformedCase().get("appeal")).getHearingType());
+    }
+
+    @Test
+    public void givenBooleanValueIsRandomText_thenSetHearingTypeToNull() {
         Map<String, Object> textBooleanValueMap = ImmutableMap.<String, Object>builder()
             .put("is_hearing_type_oral", "I am a text value")
             .put("is_hearing_type_paper", "true").build();
@@ -262,7 +314,7 @@ public class SscsCaseTransformerTest {
 
         CaseResponse result = transformer.transformExceptionRecordToCase(caseDetails);
 
-        assertTrue(result.getErrors().contains("is_hearing_type_oral does not contain a valid boolean value. Needs to be true or false"));
+        assertNull(((Appeal) result.getTransformedCase().get("appeal")).getHearingType());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/util/SscsOcrDataUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/util/SscsOcrDataUtilTest.java
@@ -158,41 +158,6 @@ public class SscsOcrDataUtilTest {
     }
 
     @Test
-    public void givenAMandatoryBooleanValueWithText_thenReturnFalseAndAddError() {
-        pairs.put("hearing_type_oral", "blue");
-
-        List<String> errors = new ArrayList<>();
-
-        assertFalse(areMandatoryBooleansValid(pairs, errors,  "hearing_type_oral"));
-        assertEquals("hearing_type_oral does not contain a valid boolean value. Needs to be true or false", errors.get(0));
-    }
-
-    @Test
-    public void givenMultipleMandatoryBooleanValuesOneBooleanOneText_thenReturnFalseAndAddOneError() {
-        pairs.put("hearing_type_oral", false);
-        pairs.put("hearing_type_paper", "blue");
-
-        List<String> errors = new ArrayList<>();
-
-        assertFalse(areMandatoryBooleansValid(pairs, errors,  "hearing_type_oral", "hearing_type_paper"));
-        assertEquals(1, errors.size());
-        assertEquals("hearing_type_paper does not contain a valid boolean value. Needs to be true or false", errors.get(0));
-    }
-
-    @Test
-    public void givenMultipleMandatoryBooleanValuesWithText_thenReturnFalseAndAddTwoErrors() {
-        pairs.put("hearing_type_oral", "red");
-        pairs.put("hearing_type_paper", "blue");
-
-        List<String> errors = new ArrayList<>();
-
-        assertFalse(areMandatoryBooleansValid(pairs, errors,  "hearing_type_oral", "hearing_type_paper"));
-        assertEquals(2, errors.size());
-        assertEquals("hearing_type_oral does not contain a valid boolean value. Needs to be true or false", errors.get(0));
-        assertEquals("hearing_type_paper does not contain a valid boolean value. Needs to be true or false", errors.get(1));
-    }
-
-    @Test
     public void givenTrue_thenReturnYes() {
         assertEquals("Yes", convertBooleanToYesNoString(true));
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/validators/SscsCaseValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/validators/SscsCaseValidatorTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.Benefit.PIP;
 import static uk.gov.hmcts.reform.sscs.constants.SscsConstants.BENEFIT_TYPE_DESCRIPTION;
+import static uk.gov.hmcts.reform.sscs.constants.SscsConstants.HEARING_TYPE_ORAL;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,7 +44,7 @@ public class SscsCaseValidatorTest {
     public void givenAnAppellantIsEmpty_thenAddAWarning() {
 
         Map<String, Object> pairs = new HashMap<>();
-        pairs.put("appeal", Appeal.builder().build());
+        pairs.put("appeal", Appeal.builder().hearingType(HEARING_TYPE_ORAL).build());
         pairs.put("bulkScanCaseReference", 123);
 
         CaseResponse response = validator.validate(pairs);
@@ -71,7 +72,8 @@ public class SscsCaseValidatorTest {
                 Address.builder().line1("123 The Road").town("Harlow").county("Essex").postcode("CM13 0GD").build())
                 .identity(Identity.builder().nino("JT1234567B").build()).build())
                 .benefitType(BenefitType.builder().code(PIP.name()).build())
-                .mrnDetails(defaultMrnDetails).build());
+                .mrnDetails(defaultMrnDetails)
+                .hearingType(HEARING_TYPE_ORAL).build());
         pairs.put("bulkScanCaseReference", 123);
 
         CaseResponse response = validator.validate(pairs);
@@ -98,7 +100,8 @@ public class SscsCaseValidatorTest {
             .address(Address.builder().line1("123 The Road").town("Harlow").county("Essex").postcode("CM13 0GD").build())
             .identity(Identity.builder().nino("JT1234567B").build()).build())
             .benefitType(BenefitType.builder().code(PIP.name()).build())
-            .mrnDetails(defaultMrnDetails).build());
+            .mrnDetails(defaultMrnDetails)
+            .hearingType(HEARING_TYPE_ORAL).build());
         pairs.put("bulkScanCaseReference", 123);
 
         CaseResponse response = validator.validate(pairs);
@@ -118,7 +121,8 @@ public class SscsCaseValidatorTest {
             Name.builder().firstName("Harry").lastName("Kane").build())
             .identity(Identity.builder().nino("JT1234567B").build()).build())
             .benefitType(BenefitType.builder().code(PIP.name()).build())
-            .mrnDetails(defaultMrnDetails).build());
+            .mrnDetails(defaultMrnDetails)
+            .hearingType(HEARING_TYPE_ORAL).build());
         pairs.put("bulkScanCaseReference", 123);
 
         CaseResponse response = validator.validate(pairs);
@@ -530,6 +534,13 @@ public class SscsCaseValidatorTest {
     }
 
     @Test
+    public void givenAnAppealWithNoHearingType_thenAddAWarning() {
+        CaseResponse response = validator.validate(buildMinimumAppealDataWithHearingType(null, buildAppellant(false), true));
+
+        assertEquals("is_hearing_type_oral and/or is_hearing_type_paper is invalid", response.getWarnings().get(0));
+    }
+
+    @Test
     public void givenAllMandatoryFieldsForAnAppellantExists_thenDoNotAddAWarning() {
         Map<String, Object> pairs = buildMinimumAppealData(buildAppellant(false), true);
 
@@ -551,26 +562,30 @@ public class SscsCaseValidatorTest {
     }
 
     private Map<String, Object> buildMinimumAppealData(Appellant appellant, Boolean exceptionCaseType) {
-        return buildMinimumAppealDataWithMrnDateAndBenefitType(defaultMrnDetails, PIP.name(), appellant, null, null, exceptionCaseType);
+        return buildMinimumAppealDataWithMrnDateAndBenefitType(defaultMrnDetails, PIP.name(), appellant, null, null, exceptionCaseType, HEARING_TYPE_ORAL);
     }
 
     private Map<String, Object> buildMinimumAppealDataWithMrn(MrnDetails mrn, Appellant appellant, Boolean exceptionCaseType) {
-        return buildMinimumAppealDataWithMrnDateAndBenefitType(mrn, PIP.name(), appellant, null, null, exceptionCaseType);
+        return buildMinimumAppealDataWithMrnDateAndBenefitType(mrn, PIP.name(), appellant, null, null, exceptionCaseType, HEARING_TYPE_ORAL);
     }
 
     private Map<String, Object> buildMinimumAppealDataWithBenefitType(String benefitCode, Appellant appellant, Boolean exceptionCaseType) {
-        return buildMinimumAppealDataWithMrnDateAndBenefitType(defaultMrnDetails, benefitCode, appellant, null, null, exceptionCaseType);
+        return buildMinimumAppealDataWithMrnDateAndBenefitType(defaultMrnDetails, benefitCode, appellant, null, null, exceptionCaseType, HEARING_TYPE_ORAL);
     }
 
     private Map<String, Object> buildMinimumAppealDataWithRepresentative(Appellant appellant, Representative representative, Boolean exceptionCaseType) {
-        return buildMinimumAppealDataWithMrnDateAndBenefitType(defaultMrnDetails, PIP.name(), appellant, representative, null, exceptionCaseType);
+        return buildMinimumAppealDataWithMrnDateAndBenefitType(defaultMrnDetails, PIP.name(), appellant, representative, null, exceptionCaseType, HEARING_TYPE_ORAL);
     }
 
     private Map<String, Object> buildMinimumAppealDataWithExcludedDate(String excludedDate, Appellant appellant, Boolean exceptionCaseType) {
-        return buildMinimumAppealDataWithMrnDateAndBenefitType(defaultMrnDetails, PIP.name(), appellant, null, excludedDate, exceptionCaseType);
+        return buildMinimumAppealDataWithMrnDateAndBenefitType(defaultMrnDetails, PIP.name(), appellant, null, excludedDate, exceptionCaseType, HEARING_TYPE_ORAL);
     }
 
-    private Map<String, Object> buildMinimumAppealDataWithMrnDateAndBenefitType(MrnDetails mrn, String benefitCode, Appellant appellant, Representative representative, String excludeDates, Boolean exceptionCaseType) {
+    private Map<String, Object> buildMinimumAppealDataWithHearingType(String hearingType, Appellant appellant, Boolean exceptionCaseType) {
+        return buildMinimumAppealDataWithMrnDateAndBenefitType(defaultMrnDetails, PIP.name(), appellant, null, null, exceptionCaseType, hearingType);
+    }
+
+    private Map<String, Object> buildMinimumAppealDataWithMrnDateAndBenefitType(MrnDetails mrn, String benefitCode, Appellant appellant, Representative representative, String excludeDates, Boolean exceptionCaseType, String hearingType) {
         Map<String, Object> dataMap = new HashMap<>();
         List<ExcludeDate> excludedDates = new ArrayList<>();
         excludedDates.add(ExcludeDate.builder().value(DateRange.builder().start(excludeDates).build()).build());
@@ -581,6 +596,7 @@ public class SscsCaseValidatorTest {
             .appellant(appellant)
             .rep(representative)
             .hearingOptions(HearingOptions.builder().excludeDates(excludedDates).build())
+            .hearingType(hearingType)
             .build());
         
         if (exceptionCaseType) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-4901


### Change description ###
- Make hearing type booleans non-mandatory
- Add warning instead of error if fields are missing
- Determine missing boolean if only one is present
- Show warning if hearing type contains invalid text


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```