### PR TITLE
Bump robotics common to 0.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,7 +187,7 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.129'
   compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '0.0.99'
-  compile group: 'uk.gov.hmcts.reform', name: 'sscs-robotics-common', version: '0.0.8'
+  compile group: 'uk.gov.hmcts.reform', name: 'sscs-robotics-common', version: '0.1.0'
   compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '1.0.4'
 
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.0.1.RELEASE'

--- a/src/test/java/uk/gov/hmcts/reform/sscs/handler/SscsRoboticsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/handler/SscsRoboticsHandlerTest.java
@@ -70,7 +70,9 @@ public class SscsRoboticsHandlerTest {
 
         SscsCaseData sscsCaseData = SscsCaseData.builder().appeal(appeal).build();
 
-        doNothing().when(roboticsService).sendCaseToRobotics(sscsCaseData, 1L, "CM12", null, Collections.emptyMap());
+        when(roboticsService
+            .sendCaseToRobotics(sscsCaseData, 1L, "CM12", null, Collections.emptyMap()))
+            .thenReturn(null);
 
         CaseResponse caseValidationResponse = CaseResponse.builder().transformedCase(transformedCase).build();
 
@@ -124,7 +126,9 @@ public class SscsRoboticsHandlerTest {
 
         Map<String, byte[]> expectedAdditionalEvidence = new HashMap<>();
         expectedAdditionalEvidence.put("test.jpg", expectedBytes);
-        doNothing().when(roboticsService).sendCaseToRobotics(sscsCaseData, 1L, "CM12", null, expectedAdditionalEvidence);
+        when(roboticsService
+            .sendCaseToRobotics(sscsCaseData, 1L, "CM12", null, expectedAdditionalEvidence))
+            .thenReturn(null);
 
         CaseResponse caseValidationResponse = CaseResponse.builder().transformedCase(transformedCase).build();
 


### PR DESCRIPTION
### Change description ###

The bump to sscs-robotics-common 0.1.0 does not affect the codebase, but does affect two tests that were previously relying on the doNothing() method which can only be used on void methods. A method that was previously void is no longer void in the library upgrade (hence the semver minor version bump)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
