### PR TITLE
Bugfix: Handle datetime from CCD

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
@@ -5,11 +5,11 @@ import static uk.gov.hmcts.reform.sscs.domain.email.EmailAttachment.*;
 import static uk.gov.hmcts.reform.sscs.util.SscsOcrDataUtil.*;
 import static uk.gov.hmcts.reform.sscs.utility.AppealNumberGenerator.generateAppealNumber;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 import lombok.extern.slf4j.Slf4j;
 import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -369,7 +369,8 @@ public class SscsCaseTransformer implements CaseTransformer {
 
 
     private String stripTimeFromDocumentDate(String documentDate) {
-        DateTimeFormatter dtf = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
-        return documentDate != null ? LocalDate.parse(documentDate, dtf).toString() : null;
+        return documentDate == null
+            ? null
+            : LocalDateTime.parse(documentDate).toLocalDate().toString();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
@@ -710,7 +710,7 @@ public class SscsCaseTransformerTest {
     }
 
     @Test
-    public void should_handle_datetimes__with_and_without_milliseconds() {
+    public void should_handle_datetimes_with_and_without_milliseconds() {
         // given
         List<ScannedRecord> scannedRecords = Arrays.asList(
             ScannedRecord.builder()

--- a/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
@@ -15,6 +15,8 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -705,6 +707,43 @@ public class SscsCaseTransformerTest {
         assertEquals(YES_LITERAL, transformedCase.get("evidencePresent"));
 
         assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    public void should_handle_datetimes__with_and_without_milliseconds() {
+        // given
+        List<ScannedRecord> scannedRecords = Arrays.asList(
+            ScannedRecord.builder()
+                .scannedDate("2019-02-20T11:22:33") // no millis
+                .controlNumber("123")
+                .url(DocumentLink.builder().documentUrl("www.test.com").build())
+                .fileName("mrn.jpg")
+                .type("Testing")
+                .subtype("My subtype").build(),
+            ScannedRecord.builder()
+                .scannedDate("2019-02-19T11:22:33.123") // with millis
+                .controlNumber("567")
+                .url(DocumentLink.builder().documentUrl("www.test.com").build())
+                .fileName("mrn.jpg")
+                .type("Testing")
+                .subtype("My subtype").build()
+        );
+        given(sscsJsonExtractor.extractJson(ocrMap))
+            .willReturn(ScannedData.builder().ocrCaseData(pairs).records(scannedRecords).build());
+
+        // when
+        CaseResponse result = transformer.transformExceptionRecordToCase(caseDetails);
+
+        // then
+        @SuppressWarnings("unchecked")
+        List<SscsDocument> docs = ((List<SscsDocument>) result.getTransformedCase().get("sscsDocument"));
+
+        Assertions.assertThat(docs)
+            .extracting(doc -> doc.getValue().getDocumentDateAdded())
+            .containsExactlyInAnyOrder(
+                "2019-02-20",
+                "2019-02-19"
+            );
     }
 
     @Test


### PR DESCRIPTION
### Change description ###
Fixes a scenario when milliseconds component of datetime is 0.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
