### PR TITLE
Sscs 5372 invalid filenames

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -31,6 +31,7 @@
     <cve>CVE-2018-19362</cve>
     <cve>CVE-2018-12022</cve>
     <cve>CVE-2018-12023</cve>
+    <cve>CVE-2018-1258</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -31,7 +31,6 @@
     <cve>CVE-2018-19362</cve>
     <cve>CVE-2018-12022</cve>
     <cve>CVE-2018-12023</cve>
-    <cve>CVE-2018-1258</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
@@ -57,5 +56,12 @@
    ]]></notes>
     <gav regex="true">^org\.codehaus\.groovy:groovy-json:.*$</gav>
     <cve>CVE-2016-6497</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   Unauthorized Access with Spring Security Method Security
+   ]]></notes>
+    <gav regex="true">.*</gav>
+    <cve>CVE-2018-1258</cve>
   </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/sscs/handler/SscsRoboticsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/handler/SscsRoboticsHandler.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocument;
 import uk.gov.hmcts.reform.sscs.ccd.service.SscsCcdConvertService;
 import uk.gov.hmcts.reform.sscs.domain.CaseEvent;
+import uk.gov.hmcts.reform.sscs.exception.UnknownFileTypeException;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscs.service.RegionalProcessingCenterService;
 import uk.gov.hmcts.reform.sscs.service.RoboticsService;
@@ -55,11 +56,16 @@ public class SscsRoboticsHandler {
                 log.info("No additional evidence downloaded for caseId {}", caseId);
             }
 
-            roboticsService.sendCaseToRobotics(sscsCaseData,
-                caseId,
-                regionalProcessingCenterService.getFirstHalfOfPostcode(sscsCaseData.getAppeal().getAppellant().getAddress().getPostcode()),
-                null,
-                additionalEvidence);
+            try {
+                roboticsService.sendCaseToRobotics(sscsCaseData,
+                    caseId,
+                    regionalProcessingCenterService.getFirstHalfOfPostcode(sscsCaseData.getAppeal().getAppellant().getAddress().getPostcode()),
+                    null,
+                    additionalEvidence);
+            } catch (UnknownFileTypeException e) {
+                log.error("Case {} is missing a valid filename on one of its SSCSDocuments", caseId, e);
+                throw e;
+            }
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/validators/SscsCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/validators/SscsCaseValidator.java
@@ -19,7 +19,6 @@ import uk.gov.hmcts.reform.sscs.bulkscancore.domain.CaseResponse;
 import uk.gov.hmcts.reform.sscs.bulkscancore.validators.CaseValidator;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.domain.CallbackType;
-import uk.gov.hmcts.reform.sscs.domain.email.EmailAttachment;
 import uk.gov.hmcts.reform.sscs.service.RegionalProcessingCenterService;
 
 @Component
@@ -74,7 +73,7 @@ public class SscsCaseValidator implements CaseValidator {
 
         isHearingTypeValid(appeal);
 
-        if(caseData.get("sscsDocument") != null) {
+        if (caseData.get("sscsDocument") != null) {
             @SuppressWarnings("unchecked")
             List<SscsDocument> lists = ((List<SscsDocument>) caseData.get("sscsDocument"));
             checkAdditionalEvidence(lists);
@@ -89,12 +88,12 @@ public class SscsCaseValidator implements CaseValidator {
             errors.add(getMessageByCallbackType(callbackType, "", BENEFIT_TYPE_DESCRIPTION, errorMessage));
         });
 
-        sscsDocuments.stream().filter(sscsDocument -> sscsDocument.getValue().getDocumentFileName() != null &&
-            sscsDocument.getValue().getDocumentFileName().indexOf('.') == -1).forEach(sscsDocument -> {
-            String errorMessage = "There is a file attached to the case called " + sscsDocument.getValue().getDocumentFileName() +
-                ", filenames must have extension, e.g. filename.pdf";
-            errors.add(getMessageByCallbackType(callbackType, "", BENEFIT_TYPE_DESCRIPTION, errorMessage));
-        });
+        sscsDocuments.stream().filter(sscsDocument -> sscsDocument.getValue().getDocumentFileName() != null
+            && sscsDocument.getValue().getDocumentFileName().indexOf('.') == -1).forEach(sscsDocument -> {
+                String errorMessage = "There is a file attached to the case called " + sscsDocument.getValue().getDocumentFileName()
+                    + ", filenames must have extension, e.g. filename.pdf";
+                errors.add(getMessageByCallbackType(callbackType, "", BENEFIT_TYPE_DESCRIPTION, errorMessage));
+            });
     }
 
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-5372


### Change description ###
Added validation for the filenames of documents.
Added case id logging for documents with invalid ids that have already got past the validation


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
