### PR TITLE
Add Bulk scan processor to the allowed services list

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -48,7 +48,7 @@ idam:
     redirectUrl: ${IDAM_OAUTH2_REDIRECT_URL:https://localhost:3000/authenticated}
     jwkUrl: ${IDAM_API_JWK_URL:http://localhost:5000/jwks}
 
-allowed-services-for-callback : ccd_data,sscs_bulkscan  # comma separated list of service names
+allowed-services-for-callback : ccd_data,sscs_bulkscan,bulk_scan_processor  # comma separated list of service names
 
 document_management.url: ${DOCUMENT_MANAGEMENT_URL:http://dm-store:5005}
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1241

### Change description ###
Bulk scan processor service need to be whitelisted in order to call the SSCS OCR validation endpoint.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
