### PR TITLE
fix bulkscan terraform

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -18,7 +18,7 @@ locals {
 }
 
 module "sscs-bulk-scan-vault" {
-  source                  = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
+  source                  = "git@github.com:hmcts/cnp-module-key-vault?ref=azurermv2"
   name                    = local.vaultName
   product                 = var.product
   env                     = var.env


### PR DESCRIPTION
The keyvault change required to remove the terraform errors is `git@github.com:hmcts/cnp-module-key-vault?ref=azurermv2` 