### PR TITLE
SSCS-9507 SSCS1U similar error message fix

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscs/BaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscs/BaseTest.java
@@ -75,8 +75,8 @@ public abstract class BaseTest {
         ccdServer.stop();
     }
 
-    protected void findCaseByForCaseworker(String eventUrl, String mrnDate) {
-        SearchSourceBuilder query = SscsQueryBuilder.findCcdCaseByNinoAndBenefitTypeAndMrnDateQuery("BB000000B", "ESA", mrnDate);
+    protected void findCaseByForCaseworker(String eventUrl, String mrnDate, String benefitType) {
+        SearchSourceBuilder query = SscsQueryBuilder.findCcdCaseByNinoAndBenefitTypeAndMrnDateQuery("BB000000B", benefitType, mrnDate);
 
         ccdServer.stubFor(post(concat(eventUrl)).atPriority(1)
             .withHeader(AUTHORIZATION, equalTo(USER_AUTH_TOKEN))

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscs/controllers/OcrValidationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscs/controllers/OcrValidationTest.java
@@ -302,7 +302,7 @@ public class OcrValidationTest  {
             .andExpect(jsonPath("$.status").value("WARNINGS"))
             .andExpect(jsonPath("$.warnings", hasSize(1)))
             .andExpect(jsonPath("$.errors", hasSize(0)))
-            .andExpect(content().json("{\"warnings\":[\"benefit_type_other is empty\"],\"errors\":[],\"status\":\"WARNINGS\"}"));
+            .andExpect(content().json("{\"warnings\":[\"benefit_type_other is invalid\"],\"errors\":[],\"status\":\"WARNINGS\"}"));
     }
 
     private String readResource(final String fileName) throws IOException {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscs/controllers/SscsBulkScanExceptionRecordCallback.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscs/controllers/SscsBulkScanExceptionRecordCallback.java
@@ -66,7 +66,7 @@ public class SscsBulkScanExceptionRecordCallback extends BaseTest {
     public void should_handle_callback_and_return_caseid_and_state_case_created_in_exception_record_data()
         throws Exception {
         checkForLinkedCases(FIND_CASE_EVENT_URL);
-        findCaseByForCaseworker(FIND_CASE_EVENT_URL, MRN_DATE_YESTERDAY_YYYY_MM_DD);
+        findCaseByForCaseworker(FIND_CASE_EVENT_URL, MRN_DATE_YESTERDAY_YYYY_MM_DD, "ESA");
 
         when(authTokenValidator.getServiceName(SERVICE_AUTH_TOKEN)).thenReturn("test_service");
 
@@ -102,7 +102,7 @@ public class SscsBulkScanExceptionRecordCallback extends BaseTest {
     @Test
     public void should_create_non_compliant_case_when_mrn_date_greater_than_13_months() throws Exception {
         checkForLinkedCases(FIND_CASE_EVENT_URL);
-        findCaseByForCaseworker(FIND_CASE_EVENT_URL, "2017-01-01");
+        findCaseByForCaseworker(FIND_CASE_EVENT_URL, "2017-01-01", "ESA");
 
         when(authTokenValidator.getServiceName(SERVICE_AUTH_TOKEN)).thenReturn("test_service");
 
@@ -253,7 +253,7 @@ public class SscsBulkScanExceptionRecordCallback extends BaseTest {
     public void auto_scan_should_handle_callback_and_return_caseid_and_state_case_created()
         throws Exception {
         checkForLinkedCases(FIND_CASE_EVENT_URL);
-        findCaseByForCaseworker(FIND_CASE_EVENT_URL, MRN_DATE_YESTERDAY_YYYY_MM_DD);
+        findCaseByForCaseworker(FIND_CASE_EVENT_URL, MRN_DATE_YESTERDAY_YYYY_MM_DD, "ESA");
 
         when(authTokenValidator.getServiceName(SERVICE_AUTH_TOKEN)).thenReturn("test_service");
 
@@ -263,8 +263,6 @@ public class SscsBulkScanExceptionRecordCallback extends BaseTest {
         ResponseEntity<SuccessfulTransformationResponse> result =
             this.restTemplate.postForEntity(baseUrl + TRANSFORM_SCANNED_DATA, request, SuccessfulTransformationResponse.class);
 
-        SuccessfulTransformationResponse callbackResponse = result.getBody();
-
         verifyResultData(result, "mappings/exception/auto-valid-appeal-response.json", this::getAppellantTya);
     }
 
@@ -272,26 +270,24 @@ public class SscsBulkScanExceptionRecordCallback extends BaseTest {
     public void auto_scan_should_handle_callback_and_return_caseid_and_state_case_created_Sscs1U()
         throws Exception {
         checkForLinkedCases(FIND_CASE_EVENT_URL);
-        findCaseByForCaseworker(FIND_CASE_EVENT_URL, MRN_DATE_YESTERDAY_YYYY_MM_DD);
+        findCaseByForCaseworker(FIND_CASE_EVENT_URL, MRN_DATE_YESTERDAY_YYYY_MM_DD, "attendanceAllowance");
 
         when(authTokenValidator.getServiceName(SERVICE_AUTH_TOKEN)).thenReturn("test_service");
 
-        HttpEntity<ExceptionRecord> request = new HttpEntity<>(autoExceptionCaseData(caseDataWithMrnDate(MRN_DATE_YESTERDAY_DD_MM_YYYY, this::addAppellant, "SSCS1U"), "SSCS1PEU"),
+        HttpEntity<ExceptionRecord> request = new HttpEntity<>(autoExceptionCaseData(caseDataWithMrnDate(MRN_DATE_YESTERDAY_DD_MM_YYYY, this::addAppellant, "SSCS1U"), "SSCS1U"),
             httpHeaders());
 
         ResponseEntity<SuccessfulTransformationResponse> result =
             this.restTemplate.postForEntity(baseUrl + TRANSFORM_SCANNED_DATA, request, SuccessfulTransformationResponse.class);
 
-        SuccessfulTransformationResponse callbackResponse = result.getBody();
-
-        verifyResultData(result, "mappings/exception/auto-valid-appeal-response.json", this::getAppellantTya);
+        verifyResultData(result, "mappings/exception/auto-valid-appeal-response-attendance-allowance.json", this::getAppellantTya);
     }
 
     @Test
     public void auto_scan_with_appointee_should_handle_callback_and_return_caseid_and_state_case_created()
         throws Exception {
         checkForLinkedCases(FIND_CASE_EVENT_URL);
-        findCaseByForCaseworker(FIND_CASE_EVENT_URL, MRN_DATE_YESTERDAY_YYYY_MM_DD);
+        findCaseByForCaseworker(FIND_CASE_EVENT_URL, MRN_DATE_YESTERDAY_YYYY_MM_DD, "ESA");
 
         when(authTokenValidator.getServiceName(SERVICE_AUTH_TOKEN)).thenReturn("test_service");
 
@@ -508,10 +504,18 @@ public class SscsBulkScanExceptionRecordCallback extends BaseTest {
                 .build());
 
         ocrList.put("mrn_date", mrnDate);
-        ocrList.put("office", "Balham DRT");
+        if (formType.toLowerCase().equals(FormType.SSCS1U.toString())) {
+            ocrList.put("office", "The Pension Service 11");
+        } else {
+            ocrList.put("office", "Balham DRT");
+        }
         ocrList.put("contains_mrn", true);
+
         if (formType.toLowerCase().equals(FormType.SSCS1.toString())) {
             ocrList.put("benefit_type_description", "ESA");
+        } else if (formType.toLowerCase().equals(FormType.SSCS1U.toString())) {
+            ocrList.put("is_benefit_type_other", false);
+            ocrList.put("benefit_type_other", "Attendance Allowance");
         } else {
             ocrList.put("is_benefit_type_esa", "true");
         }

--- a/src/integrationTest/resources/mappings/exception/auto-valid-appeal-response-attendance-allowance.json
+++ b/src/integrationTest/resources/mappings/exception/auto-valid-appeal-response-attendance-allowance.json
@@ -1,0 +1,134 @@
+{
+  "case_creation_details": {
+    "case_data": {
+      "appeal": {
+        "mrnDetails": {
+          "dwpIssuingOffice": "The Pension Service 11",
+          "mrnDate": "MRN_DATE",
+          "mrnLateReason": null,
+          "mrnMissingReason": null
+        },
+        "appellant": {
+          "name": {
+            "title": "Mr",
+            "firstName": "John",
+            "lastName": "Smith"
+          },
+          "address": {
+            "line1": "2 Drake Close",
+            "line2": "Hutton",
+            "town": "Brentwood",
+            "county": "Essex",
+            "postcode": "CM13 1AQ"
+          },
+          "contact": {
+            "email": null,
+            "phone": "01234567899",
+            "mobile": "07411222222"
+          },
+          "identity": {
+            "dob": "1976-11-11",
+            "nino": "BB000000B"
+          },
+          "appointee": null,
+          "isAppointee": "No",
+          "isAddressSameAsAppointee": null
+        },
+        "benefitType": {
+          "code": "attendanceAllowance",
+          "description": "Attendance Allowance"
+        },
+        "hearingSubtype": {
+          "wantsHearingTypeTelephone": "Yes",
+          "hearingTelephoneNumber": "01234567890",
+          "wantsHearingTypeVideo": "Yes",
+          "hearingVideoEmail": "my@email.com",
+          "wantsHearingTypeFaceToFace": "No"
+        },
+        "hearingOptions": {
+          "wantsToAttend": "Yes",
+          "wantsSupport": "No",
+          "languageInterpreter": "No",
+          "arrangements": [],
+          "scheduleHearing": "Yes",
+          "excludeDates": [
+            {
+              "value": {
+                "start": "2030-12-01",
+                "end": null
+              }
+            }
+          ]
+        },
+        "appealReasons": null,
+        "rep": {
+          "hasRepresentative": "No",
+          "organisation": null,
+          "name": null,
+          "address": null,
+          "contact": null
+        },
+        "signer": null,
+        "hearingType": "oral",
+        "receivedVia": "Paper"
+      },
+      "sscsDocument": [
+        {
+          "value": {
+            "documentType": "appellantEvidence",
+            "documentFileName": "11111.pdf",
+            "documentDateAdded": "2018-10-10",
+            "documentLink": {
+              "document_url": "http://www.bbc.com",
+              "document_binary_url": "http://www.bbc.com/binary",
+              "document_filename": "myfile.jpg"
+            }
+          }
+        }
+      ],
+      "subscriptions": {
+        "appellantSubscription": {
+          "wantSmsNotifications": "No",
+          "email": null,
+          "mobile": "07411222222",
+          "subscribeEmail": "No",
+          "subscribeSms": "No",
+          "reason": null,
+          "lastLoggedIntoMya": null,
+          "tya": "TYA_RANDOM_NUMBER"
+        },
+        "supporterSubscription": null,
+        "representativeSubscription": null,
+        "appointeeSubscription": null,
+        "jointPartySubscription": null
+      },
+      "region": "BRADFORD",
+      "regionalProcessingCenter": {
+        "name": "BRADFORD",
+        "address1": "HM Courts & Tribunals Service",
+        "address2": "Social Security & Child Support Appeals",
+        "address3": "Phoenix House",
+        "address4": "Rushton Avenue",
+        "city": "BRADFORD",
+        "postcode": "BD3 7BH",
+        "phoneNumber": "0300 123 1142",
+        "faxNumber": "0126 434 7983",
+        "email": "SSCS_Bradford@justice.gov.uk"
+      },
+      "processingVenue": "Basildon Combined Court",
+      "evidencePresent": "Yes",
+      "bulkScanCaseReference": "1234567891011",
+      "benefitCode": "013",
+      "caseCode": "013DD",
+      "caseCreated": "2018-01-11",
+      "createdInGapsFrom": "readyToList",
+      "dwpRegionalCentre": "Attendance Allowance",
+      "issueCode": "DD",
+      "linkedCasesBoolean": "No",
+      "formType": "sscs1u"
+    },
+    "case_type_id": "Benefit",
+    "event_id": "validAppealCreated"
+  },
+  "warnings": []
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
@@ -315,7 +315,7 @@ public class SscsCaseTransformer implements CaseTransformer {
 
         Optional<Benefit> benefit = Benefit.findBenefitByShortName(code);
 
-        if (benefit.isEmpty() && errors.size() == 0) {
+        if (benefit.isEmpty() && errors.isEmpty()) {
             // only add when no other errors, otherwise similar errors get added to the list
             errors.add(BENEFIT_TYPE_OTHER + " " + IS_INVALID);
         }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
@@ -287,6 +287,7 @@ public class SscsCaseTransformer implements CaseTransformer {
         // Extract all the provided benefit type booleans, outputting errors for any that are invalid
         List<String> validProvidedBooleanValues = extractValuesWhereBooleansValid(pairs, errors, BenefitTypeIndicatorSscs1U.getAllIndicatorStrings());
 
+
         if (!validProvidedBooleanValues.isEmpty()
             && !isExactlyZeroBooleanTrue(pairs, errors, validProvidedBooleanValues.toArray(new String[validProvidedBooleanValues.size()]))) {
             // Of the provided benefit type booleans (if any), check that exactly one is set to true, outputting errors
@@ -311,7 +312,13 @@ public class SscsCaseTransformer implements CaseTransformer {
                     .replace(IS_BENEFIT_TYPE_OTHER, BENEFIT_TYPE_OTHER));
             }
         }
+
         Optional<Benefit> benefit = Benefit.findBenefitByShortName(code);
+
+        if (benefit.isEmpty() && errors.size() == 0) {
+            // only add when no other errors, otherwise similar errors get added to the list
+            errors.add(BENEFIT_TYPE_OTHER + " " + IS_INVALID);
+        }
         return (benefit.isPresent() && errors.size() == 0) ? BenefitType.builder().code(code).description(benefit.get().getDescription()).build() : null;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/validators/SscsCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/validators/SscsCaseValidator.java
@@ -513,9 +513,7 @@ public class SscsCaseValidator implements CaseValidator {
                     .build());
             }
         } else {
-            if (formType != null && formType.equals(FormType.SSCS1U)) {
-                warnings.add(getMessageByCallbackType(callbackType, "", BENEFIT_TYPE_OTHER, IS_EMPTY));
-            } else {
+            if (formType == null || (formType != null && !formType.equals(FormType.SSCS1U))) {
                 warnings.add(getMessageByCallbackType(callbackType, "", BENEFIT_TYPE_DESCRIPTION, IS_EMPTY));
             }
         }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/validators/SscsCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/validators/SscsCaseValidator.java
@@ -513,7 +513,7 @@ public class SscsCaseValidator implements CaseValidator {
                     .build());
             }
         } else {
-            if (formType == null || (formType != null && !formType.equals(FormType.SSCS1U))) {
+            if (formType == null || !formType.equals(FormType.SSCS1U)) {
                 warnings.add(getMessageByCallbackType(callbackType, "", BENEFIT_TYPE_DESCRIPTION, IS_EMPTY));
             }
         }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
@@ -249,7 +249,7 @@ public class SscsCaseTransformerTest {
         pairs.put(BenefitTypeIndicatorSscs1U.OTHER.getIndicatorString(), true);
         pairs.put(BENEFIT_TYPE_OTHER, "Not a valid type");
         CaseResponse result = transformer.transformExceptionRecord(sscs1UExceptionRecord, false);
-        assertTrue(result.getErrors().size() == 1);
+        assertEquals(1, result.getErrors().size());
         assertEquals("benefit_type_other is invalid", result.getErrors().get(0));
     }
 
@@ -260,7 +260,7 @@ public class SscsCaseTransformerTest {
         pairs.put(BenefitTypeIndicatorSscs1U.UC.getIndicatorString(), false);
         pairs.put(BenefitTypeIndicatorSscs1U.OTHER.getIndicatorString(), true);
         CaseResponse result = transformer.transformExceptionRecord(sscs1UExceptionRecord, false);
-        assertTrue(result.getErrors().size() == 1);
+        assertEquals(1, result.getErrors().size());
         assertEquals("benefit_type_other is invalid", result.getErrors().get(0));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
@@ -193,19 +193,6 @@ public class SscsCaseTransformerTest {
     }
 
     @Test
-    public void givenBenefitTypeIsOther_thenNullCodeIsReturned() {
-        pairs.put(BenefitTypeIndicatorSscs1U.PIP.getIndicatorString(), false);
-        pairs.put(BenefitTypeIndicatorSscs1U.ESA.getIndicatorString(), false);
-        pairs.put(BenefitTypeIndicatorSscs1U.UC.getIndicatorString(), false);
-        pairs.put(BenefitTypeIndicatorSscs1U.OTHER.getIndicatorString(), true);
-        CaseResponse result = transformer.transformExceptionRecord(sscs1UExceptionRecord, false);
-        assertTrue(result.getErrors().isEmpty());
-        Appeal appeal = (Appeal) result.getTransformedCase().get("appeal");
-
-        assertEquals(null,  appeal.getBenefitType());
-    }
-
-    @Test
     public void givenBenefitTypeIsOtherAttendanceAllowance_thenCorrectCodeIsReturned() {
         pairs.put(BenefitTypeIndicatorSscs1U.PIP.getIndicatorString(), false);
         pairs.put(BenefitTypeIndicatorSscs1U.ESA.getIndicatorString(), false);
@@ -253,7 +240,7 @@ public class SscsCaseTransformerTest {
     }
 
     @Test
-    public void givenBenefitTypeIsOtherWithInvalidType_thenNoErrorMessageReturned() {
+    public void givenBenefitTypeIsOtherWithInvalidType_thenErrorMessageReturned() {
         pairs.remove("is_benefit_type_pip");
         pairs.put(BenefitTypeIndicatorSscs1U.ESA.getIndicatorString(), false);
         pairs.put(BenefitTypeIndicatorSscs1U.PIP.getIndicatorString(), false);
@@ -262,7 +249,19 @@ public class SscsCaseTransformerTest {
         pairs.put(BenefitTypeIndicatorSscs1U.OTHER.getIndicatorString(), true);
         pairs.put(BENEFIT_TYPE_OTHER, "Not a valid type");
         CaseResponse result = transformer.transformExceptionRecord(sscs1UExceptionRecord, false);
-        assertTrue(result.getErrors().size() == 0);
+        assertTrue(result.getErrors().size() == 1);
+        assertEquals("benefit_type_other is invalid", result.getErrors().get(0));
+    }
+
+    @Test
+    public void givenBenefitTypeIsOther_thenNullCodeIsReturned() {
+        pairs.put(BenefitTypeIndicatorSscs1U.PIP.getIndicatorString(), false);
+        pairs.put(BenefitTypeIndicatorSscs1U.ESA.getIndicatorString(), false);
+        pairs.put(BenefitTypeIndicatorSscs1U.UC.getIndicatorString(), false);
+        pairs.put(BenefitTypeIndicatorSscs1U.OTHER.getIndicatorString(), true);
+        CaseResponse result = transformer.transformExceptionRecord(sscs1UExceptionRecord, false);
+        assertTrue(result.getErrors().size() == 1);
+        assertEquals("benefit_type_other is invalid", result.getErrors().get(0));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/validators/SscsCaseValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/validators/SscsCaseValidatorTest.java
@@ -875,12 +875,12 @@ public class SscsCaseValidatorTest {
     }
 
     @Test
-    public void givenAnAppealDoesNotContainABenefitTypeOther_thenAddAWarning() {
+    public void givenAnAppealDoesNotContainABenefitTypeOtherForSscs1UForm_thenDoNotAddAWarning() {
         Map<String, Object> caseData = buildMinimumAppealDataWithBenefitType(null, buildAppellant(false), true);
         caseData.put("formType", FormType.SSCS1U);
         CaseResponse response = validator.validateExceptionRecord(transformResponse, exceptionRecordSscs1U, caseData, false);
 
-        assertEquals(BENEFIT_TYPE_OTHER + " is empty", response.getWarnings().get(0));
+        assertTrue(response.getWarnings().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/SSCS-9507

There were 2 errors that were similar getting added to the error message list when a benefit type other was invalid. This is because one version was added in the Transformer and another in the Validator. Therefore, changed the logic so the error for SSCS1U form is only added in the Transformer where it only adds if the previous one is not already present. 