### PR TITLE
sscs-9839 Set hearingOptions.scheduleHearing when unavailable dates p…

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
@@ -768,7 +768,7 @@ public class SscsCaseTransformer implements CaseTransformer {
 
         String languageType = isLanguageInterpreterRequired ? findLanguageTypeString(pairs) : null;
 
-        String wantsToAttend = (hearingType.equals(HEARING_TYPE_ORAL)) ? YES_LITERAL : NO_LITERAL;
+        String wantsToAttend = hearingType != null && hearingType.equals(HEARING_TYPE_ORAL) ? YES_LITERAL : NO_LITERAL;
 
         List<String> arrangements = buildArrangements(pairs, isSignLanguageInterpreterRequired);
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
@@ -688,13 +688,11 @@ public class SscsCaseTransformer implements CaseTransformer {
         checkBooleanValue(pairs, errors, IS_HEARING_TYPE_ORAL_LITERAL);
         checkBooleanValue(pairs, errors, IS_HEARING_TYPE_PAPER_LITERAL);
         if (checkBooleanValue(pairs, errors, IS_HEARING_TYPE_ORAL_LITERAL)
-            && (pairs.get(IS_HEARING_TYPE_PAPER_LITERAL) == null
-            || pairs.get(IS_HEARING_TYPE_PAPER_LITERAL).equals("null"))) {
+            && (!pairs.containsKey(IS_HEARING_TYPE_PAPER_LITERAL) || pairs.get(IS_HEARING_TYPE_PAPER_LITERAL).equals("null"))) {
             pairs.put(IS_HEARING_TYPE_PAPER_LITERAL,
                 !Boolean.parseBoolean(pairs.get(IS_HEARING_TYPE_ORAL_LITERAL).toString()));
         } else if (checkBooleanValue(pairs, errors, IS_HEARING_TYPE_PAPER_LITERAL)
-            && (pairs.get(IS_HEARING_TYPE_ORAL_LITERAL) == null
-            || pairs.get(IS_HEARING_TYPE_ORAL_LITERAL).equals("null"))) {
+            && (!pairs.containsKey(IS_HEARING_TYPE_ORAL_LITERAL) || pairs.get(IS_HEARING_TYPE_ORAL_LITERAL).equals("null"))) {
             pairs.put(IS_HEARING_TYPE_ORAL_LITERAL,
                 !Boolean.parseBoolean(pairs.get(IS_HEARING_TYPE_PAPER_LITERAL).toString()));
         }
@@ -770,7 +768,7 @@ public class SscsCaseTransformer implements CaseTransformer {
 
         String languageType = isLanguageInterpreterRequired ? findLanguageTypeString(pairs) : null;
 
-        String wantsToAttend = hearingType != null && hearingType.equals(HEARING_TYPE_ORAL) ? YES_LITERAL : NO_LITERAL;
+        String wantsToAttend = (hearingType.equals(HEARING_TYPE_ORAL)) ? YES_LITERAL : NO_LITERAL;
 
         List<String> arrangements = buildArrangements(pairs, isSignLanguageInterpreterRequired);
 
@@ -778,7 +776,6 @@ public class SscsCaseTransformer implements CaseTransformer {
 
         List<ExcludeDate> excludedDates =
             extractExcludedDates(pairs, getField(pairs, HEARING_OPTIONS_EXCLUDE_DATES_LITERAL));
-        ;
 
         String agreeLessNotice = checkBooleanValue(pairs, errors, AGREE_LESS_HEARING_NOTICE_LITERAL)
             ? convertBooleanToYesNoString(getBoolean(pairs, errors, AGREE_LESS_HEARING_NOTICE_LITERAL)) : null;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformer.java
@@ -688,11 +688,11 @@ public class SscsCaseTransformer implements CaseTransformer {
         checkBooleanValue(pairs, errors, IS_HEARING_TYPE_ORAL_LITERAL);
         checkBooleanValue(pairs, errors, IS_HEARING_TYPE_PAPER_LITERAL);
         if (checkBooleanValue(pairs, errors, IS_HEARING_TYPE_ORAL_LITERAL)
-            && (!pairs.containsKey(IS_HEARING_TYPE_PAPER_LITERAL) || pairs.get(IS_HEARING_TYPE_PAPER_LITERAL).equals("null"))) {
+            && (pairs.get(IS_HEARING_TYPE_PAPER_LITERAL) == null || pairs.get(IS_HEARING_TYPE_PAPER_LITERAL).equals("null"))) {
             pairs.put(IS_HEARING_TYPE_PAPER_LITERAL,
                 !Boolean.parseBoolean(pairs.get(IS_HEARING_TYPE_ORAL_LITERAL).toString()));
         } else if (checkBooleanValue(pairs, errors, IS_HEARING_TYPE_PAPER_LITERAL)
-            && (!pairs.containsKey(IS_HEARING_TYPE_ORAL_LITERAL) || pairs.get(IS_HEARING_TYPE_ORAL_LITERAL).equals("null"))) {
+            && (pairs.get(IS_HEARING_TYPE_PAPER_LITERAL) == null || pairs.get(IS_HEARING_TYPE_ORAL_LITERAL).equals("null"))) {
             pairs.put(IS_HEARING_TYPE_ORAL_LITERAL,
                 !Boolean.parseBoolean(pairs.get(IS_HEARING_TYPE_PAPER_LITERAL).toString()));
         }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
@@ -1105,6 +1105,35 @@ public class SscsCaseTransformerTest {
     }
 
     @Test
+    public void givenSingleExcludedDate_thenBuildAnAppealWithExcludedStartDateAndWantToAttendYes() {
+
+        pairs.put("hearing_options_exclude_dates", HEARING_OPTIONS_EXCLUDE_DATES);
+
+        CaseResponse result = transformer.transformExceptionRecord(exceptionRecord, false);
+
+        assertEquals("2030-12-01", ((Appeal) result.getTransformedCase().get("appeal")).getHearingOptions().getExcludeDates().get(0).getValue().getStart());
+        assertEquals(YES_LITERAL, ((Appeal) result.getTransformedCase().get("appeal")).getHearingOptions().getWantsToAttend());
+
+        assertTrue(result.getErrors().isEmpty());
+    }
+    @Test
+    public void givenMultipleExcludedDates_thenBuildAnAppealWithExcludedDatesAndWantToAttendYes() {
+
+        pairs.put("hearing_options_exclude_dates", "01/12/2030, 15/12/2030-31/12/2030");
+
+        CaseResponse result = transformer.transformExceptionRecord(exceptionRecord, false);
+
+        List<ExcludeDate> excludeDateList = ((Appeal) result.getTransformedCase().get("appeal")).getHearingOptions().getExcludeDates();
+
+        assertEquals("2030-12-01", excludeDateList.get(0).getValue().getStart());
+        assertEquals("2030-12-15", excludeDateList.get(1).getValue().getStart());
+        assertEquals("2030-12-31", excludeDateList.get(1).getValue().getEnd());
+        assertEquals(YES_LITERAL, ((Appeal) result.getTransformedCase().get("appeal")).getHearingOptions().getWantsToAttend());
+
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
     public void givenNoExcludedDate_thenBuildAnAppealWithExcludedStartDateAndScheduleHearingNo() {
 
         CaseResponse result = transformer.transformExceptionRecord(exceptionRecord, false);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/transformers/SscsCaseTransformerTest.java
@@ -1116,6 +1116,7 @@ public class SscsCaseTransformerTest {
 
         assertTrue(result.getErrors().isEmpty());
     }
+
     @Test
     public void givenMultipleExcludedDates_thenBuildAnAppealWithExcludedDatesAndWantToAttendYes() {
 


### PR DESCRIPTION
…rovided

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-9839

### Change description ###
At the moment when users are creating an appeal via the bulk scan route, if they provide dates that they are unable to attend a hearing, then this isn’t visible on the UI, because the flag that shows the field isn’t populated – this ticket is to look at fixing this.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
