### PR TITLE
SSCS-11066-build gradle is updated to have new sscs common version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -223,7 +223,7 @@ dependencies {
   compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.54'
   compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.54'
   compile group: 'org.apache.tomcat', name: 'tomcat-annotations-api', version: '10.0.14'
-  compile group: 'com.github.hmcts', name: 'sscs-common', version: '4.6.38'
+  compile group: 'com.github.hmcts', name: 'sscs-common', version: '4.6.45-RC-SSCS-10166'
 
   compile group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.3'
   compile group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.3'

--- a/build.gradle
+++ b/build.gradle
@@ -223,7 +223,7 @@ dependencies {
   compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.54'
   compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.54'
   compile group: 'org.apache.tomcat', name: 'tomcat-annotations-api', version: '10.0.14'
-  compile group: 'com.github.hmcts', name: 'sscs-common', version: '4.6.45-RC-SSCS-10166'
+  compile group: 'com.github.hmcts', name: 'sscs-common', version: '4.6.45'
 
   compile group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.3'
   compile group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.3'


### PR DESCRIPTION
Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-10166


### Change description ###
poi and opencvs versions are updated in sscs-common and sscs-pdf-email-common as the security vulnerabilities they have are preventing feature developments


**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
