### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -220,7 +220,7 @@ dependencies {
   implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
 
   implementation group: 'com.github.hmcts', name: 'properties-volume-spring-boot-starter', version: '0.1.0'
-  implementation group: 'com.github.hmcts', name: 'java-logging', version: '5.1.9'
+  implementation group: 'com.github.hmcts', name: 'java-logging', version: '6.0.1'
   implementation group: 'com.github.hmcts', name: 'ccd-client', version: '4.8.6'
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.3'


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.