### PR TITLE
CVE dependency patches and minors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,7 +212,7 @@ dependencies {
   implementation group: 'io.rest-assured', name: 'json-path', version: '4.3.3'
   implementation group: 'io.rest-assured', name: 'xml-path', version: '4.3.3'
   implementation group: 'io.github.openfeign', name: 'feign-jackson', version: '11.0'
-  implementation group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: '1.14.2'
+  implementation group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: '1.14.3'
   implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
   implementation group: 'org.elasticsearch', name: 'elasticsearch', version: '7.17.9'
 

--- a/build.gradle
+++ b/build.gradle
@@ -356,6 +356,9 @@ dependencyManagement {
         entry 'jackson-core'
         entry 'jackson-annotations'
     }
+
+    // CVE-2023-33202
+    dependency group: 'org.springframework.security', name: 'spring-security-rsa', version: '1.1.1'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -227,7 +227,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.3'
 
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5.3.4'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5.3.6'
 
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.3'
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.3'

--- a/build.gradle
+++ b/build.gradle
@@ -289,7 +289,7 @@ dependencyManagement {
      dependency group: 'org.apache.santuario', name: 'xmlsec', version: '3.0.1'
 
     // CVE-2019-0232, CVE-2019-0199 - command line injections on windows
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.75') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.86') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'

--- a/build.gradle
+++ b/build.gradle
@@ -227,7 +227,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.3'
 
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5.3.0'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5.3.4'
 
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.3'
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.3'
@@ -312,10 +312,6 @@ dependencyManagement {
 
     dependencySet(group: 'org.apache.xmlgraphics', version: '1.16') {
       entry 'batik-all'
-    }
-
-    dependencySet(group: 'org.apache.commons', version: '1.22') {
-      entry 'commons-compress'
     }
 
     dependencySet(group: 'org.yaml', version: '1.33') {

--- a/build.gradle
+++ b/build.gradle
@@ -365,6 +365,9 @@ dependencyManagement {
       entry 'logback-core'
       entry 'logback-classic'
     }
+
+    // CVE-2023-34042
+    dependency group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.8.10'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -359,6 +359,12 @@ dependencyManagement {
 
     // CVE-2023-33202
     dependency group: 'org.springframework.security', name: 'spring-security-rsa', version: '1.1.1'
+
+    //CVE-2023-6378, CVE-2023-6481
+    dependencySet(group: 'ch.qos.logback', version: '1.2.13') {
+      entry 'logback-core'
+      entry 'logback-classic'
+    }
   }
 }
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -3,7 +3,6 @@
   <suppress until="2024-04-01">
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2023-35116</cve>
-    <cve>CVE-2023-24998</cve>
     <cve>CVE-2023-42503</cve>
     <cve>CVE-2023-33202</cve>
     <cve>CVE-2023-6378</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,18 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until="2024-04-01">
-    <cve>CVE-2023-42794</cve>
-    <cve>CVE-2023-44487</cve>
-    <cve>CVE-2023-42795</cve>
-    <cve>CVE-2023-45648</cve>
-    <cve>CVE-2023-41080</cve>
     <cve>CVE-2023-5072</cve>
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-24998</cve>
     <cve>CVE-2023-42503</cve>
     <cve>CVE-2023-33202</cve>
-    <cve>CVE-2023-46589</cve>
     <cve>CVE-2023-6378</cve>
     <cve>CVE-2023-6481</cve>
     <cve>CVE-2023-34042</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -4,8 +4,6 @@
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-42503</cve>
-    <cve>CVE-2023-6378</cve>
-    <cve>CVE-2023-6481</cve>
     <cve>CVE-2023-34042</cve>
     <cve>CVE-2024-26308</cve>
   </suppress>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -3,7 +3,5 @@
   <suppress until="2024-04-01">
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2023-35116</cve>
-    <cve>CVE-2023-42503</cve>
-    <cve>CVE-2024-26308</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -10,7 +10,6 @@
     <cve>CVE-2023-6378</cve>
     <cve>CVE-2023-6481</cve>
     <cve>CVE-2023-34042</cve>
-    <cve>CVE-2024-25710</cve>
     <cve>CVE-2024-26308</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -4,7 +4,6 @@
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-42503</cve>
-    <cve>CVE-2023-34042</cve>
     <cve>CVE-2024-26308</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until="2024-04-01">
-    <cve>CVE-2023-5072</cve>
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-24998</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -4,7 +4,6 @@
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-42503</cve>
-    <cve>CVE-2023-33202</cve>
     <cve>CVE-2023-6378</cve>
     <cve>CVE-2023-6481</cve>
     <cve>CVE-2023-34042</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCSCI-781

### Change description ###


CVE-2023-42794, CVE-2023-44487, CVE-2023-42795, CVE-2023-45648, CVE-2023-41080, CVE-2023-46589
Can't update spring boot because the build will fail, from spring boot 2.6.0 `the default strategy for matching request paths against registered Spring MVC handler mappings has changed from AntPathMatcher to PathPatternParser` and `if you are using Actuator and Springfox, this may result in your application failing to start` ([Spring-Boot-2.6-Release-Notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#pathpattern-based-path-matching-strategy-for-spring-mvc)) . **Patched already existing dependency** of org.apache.tomcat.embed to 9.0.86 (latest). 

CVE-2023-42503
CVE was coming from sscs-common and was fixed in tag 5.3.4. After the upgrade of sscs-common to 5.3.6, **removed existing dependency** as commons-compress is a dependency of sscs-common via org.apache.poi:poi-ooxml.

CVE-2023-5072
**Patched** org.everit.json.schema to version 1.14.3, it's a direct dependency and org.json:json:20230227is a dependency of this package only

CVE-2022-1471
No minor or patch is available, **suppressing** for now. The available fix is a major (2.0) or the latest version is 2.2.

CVE-2023-35116
Upgrading to recommended version 2.16.0 breaks the build with error:

```
CcdCallbackControllerTest > should_throw_unauthenticated_exception_when_auth_header_is_missing FAILED  
java.lang.AssertionError at CcdCallbackControllerTest.java:105

CcdCallbackControllerTest > should_successfully_handle_callback_and_return_validate_response FAILED  
java.lang.AssertionError at CcdCallbackControllerTest.java:65  
Caused by: com.jayway.jsonpath.PathNotFoundException at CcdCallbackControllerTest.java:65

CcdCallbackControllerTest > should_throw_unauthorized_exception_when_auth_header_is_missing FAILED  
java.lang.AssertionError at CcdCallbackControllerTest.java:121
```
**Suppressing** for now. A spring-boot upgrade to latest version would fix the CVE.

CVE-2023-24998
Upgrade of sscs-commons fixed this CVE

CVE-2023-33202
**Added a new dependency** to org.springframework.security:spring-security-rsa:1.1.1, upgrades of other packages didn't fix the CVE and the alternative solution could be upgrading spring-boot.

CVE-2023-6378, CVE-2023-6481
Added patch as a **new dependency set** (couldn't use any direct dependencies to fix CVE) but should upgrade org.springframework.boot.

CVE-2023-34042
Added a **new dependency** to fix the CVE, should upgrade spring-boot instead.

