### PR TITLE
SSCSCI-995-jackson-databind-bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -234,7 +234,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.3'
 
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '102fb28'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '79b8ed9'
 
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.4'
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.4'

--- a/build.gradle
+++ b/build.gradle
@@ -234,7 +234,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.3'
 
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '304cc79'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5.12.12'
 
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.4'
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.4'

--- a/build.gradle
+++ b/build.gradle
@@ -234,7 +234,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.3'
 
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '79b8ed9'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '16fff13'
 
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.4'
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.4'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
   id 'jacoco'
   id 'info.solidsoft.pitest' version '1.9.11'
   id 'io.spring.dependency-management' version '1.0.12.RELEASE'
-  id 'org.springframework.boot' version '2.5.15'
+  id 'org.springframework.boot' version '2.7.18'
   id 'uk.gov.hmcts.java' version '0.12.12'
   id 'org.owasp.dependencycheck' version '10.0.3'
   id 'com.github.ben-manes.versions' version '0.46.0'
@@ -225,8 +225,9 @@ dependencies {
   implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
   implementation group: 'org.elasticsearch', name: 'elasticsearch', version: '7.17.9'
 
-  implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
-  implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+//  implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
+  implementation group: 'io.springfox', name: 'springfox-boot-starter', version: '3.0.0'
+  implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '3.0.0'
 
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.0.1'
 
@@ -271,7 +272,7 @@ dependencies {
   testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.9.2'
   testImplementation group: 'org.apiguardian', name: 'apiguardian-api', version: '1.1.2'
 
-  integrationTestImplementation(group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: '3.1.6') {
+  integrationTestImplementation(group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: '3.1.10') {
     exclude group: "com.github.tomakehurst", module: "wiremock-standalone"
   }
 
@@ -351,7 +352,7 @@ dependencyManagement {
     }
 
     imports {
-      mavenBom "org.springframework.cloud:spring-cloud-dependencies:2020.0.6"
+      mavenBom "org.springframework.cloud:spring-cloud-dependencies:2021.0.8"
     }
     //CVE-2021-28170
     dependency group: 'org.glassfish', name: 'jakarta.el', version: '4.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -234,7 +234,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.3'
 
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: 'b097914'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: 'b0832a7'
 
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.4'
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.4'

--- a/build.gradle
+++ b/build.gradle
@@ -225,9 +225,7 @@ dependencies {
   implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
   implementation group: 'org.elasticsearch', name: 'elasticsearch', version: '7.17.9'
 
-//  implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
-  implementation group: 'io.springfox', name: 'springfox-boot-starter', version: '3.0.0'
-  implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '3.0.0'
+  implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
 
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.0.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -234,7 +234,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.3'
 
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5a569e2'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: 'cb61d43'
 
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.4'
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.4'

--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.3'
 
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5.9.1'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5a569e2'
 
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.3'
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.3'
@@ -357,7 +357,7 @@ dependencyManagement {
     dependency group: 'org.glassfish', name: 'jakarta.el', version: '4.0.2'
 
     //CVE-2020-36518, CVE-2022-42004
-    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.14.3') {
+    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.17.2') {
         entry 'jackson-databind'
         entry 'jackson-core'
         entry 'jackson-annotations'

--- a/build.gradle
+++ b/build.gradle
@@ -234,7 +234,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.3'
 
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '16fff13'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: 'b097914'
 
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.4'
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.4'

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ plugins {
   id 'info.solidsoft.pitest' version '1.9.11'
   id 'io.spring.dependency-management' version '1.1.6'
   id 'org.springframework.boot' version '2.7.18'
-  id 'uk.gov.hmcts.java' version '0.12.12'
-  id 'org.owasp.dependencycheck' version '10.0.3'
+  id 'uk.gov.hmcts.java' version '0.12.63'
+  id 'org.owasp.dependencycheck' version '10.0.4'
   id 'com.github.ben-manes.versions' version '0.46.0'
 }
 
@@ -214,60 +214,60 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: springBoot.class.package.implementationVersion
 
   // https://mvnrepository.com/artifact/org.springframework.retry/spring-retry
-  implementation group: 'org.springframework.retry', name: 'spring-retry', version: '1.3.4'
+  implementation group: 'org.springframework.retry', name: 'spring-retry', version: '2.0.9'
 
   implementation group: 'me.xdrop', name: 'fuzzywuzzy', version: '1.4.0'
-  implementation group: 'io.rest-assured', name: 'rest-assured', version: '4.3.3'
-  implementation group: 'io.rest-assured', name: 'json-path', version: '4.3.3'
-  implementation group: 'io.rest-assured', name: 'xml-path', version: '4.3.3'
-  implementation group: 'io.github.openfeign', name: 'feign-jackson', version: '11.0'
-  implementation group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: '1.14.3'
+  implementation group: 'io.rest-assured', name: 'rest-assured', version: '4.5.1'
+  implementation group: 'io.rest-assured', name: 'json-path', version: '4.5.1'
+  implementation group: 'io.rest-assured', name: 'xml-path', version: '4.5.1'
+  implementation group: 'io.github.openfeign', name: 'feign-jackson', version: '13.3'
+  implementation group: 'com.github.everit-org.json-schema', name: 'org.everit.json.schema', version: '1.14.4'
   implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
   implementation group: 'org.elasticsearch', name: 'elasticsearch', version: '7.17.9'
 
   implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.7.0'
 
-  implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.0.1'
+  implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.4'
 
-  implementation group: 'com.github.hmcts', name: 'java-logging', version: '6.0.1'
-  implementation group: 'com.github.hmcts', name: 'ccd-client', version: '4.8.6'
+  implementation group: 'com.github.hmcts', name: 'java-logging', version: '6.1.6'
+  implementation group: 'com.github.hmcts', name: 'ccd-client', version: '5.0.3'
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.3'
 
   implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5a569e2'
 
-  implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.3'
-  implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.3'
+  implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.4'
+  implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.4'
 
   implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
   implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
 
-  implementation group: 'org.projectlombok', name: 'lombok', version: '1.18.26'
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.26'
+  implementation group: 'org.projectlombok', name: 'lombok', version: '1.18.34'
+  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.34'
 
-  testImplementation group: 'org.projectlombok', name: 'lombok', version: '1.18.26'
-  testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.26'
-  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.3', classifier: 'all'
+  testImplementation group: 'org.projectlombok', name: 'lombok', version: '1.18.34'
+  testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.34'
+  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.4', classifier: 'all'
   testImplementation group: 'com.h2database', name: 'h2', version: '2.1.214'
 
-  functionalTestImplementation group: 'org.projectlombok', name: 'lombok', version: '1.18.26'
-  functionalTestAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.26'
+  functionalTestImplementation group: 'org.projectlombok', name: 'lombok', version: '1.18.34'
+  functionalTestAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.34'
 
   testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBoot.class.package.implementationVersion) {
     exclude group: "com.vaadin.external.google", module: "android-json"
   }
 
   testImplementation group: 'pl.pragmatists', name: 'JUnitParams', version: '1.1.1'
-  testImplementation group: 'net.javacrumbs.json-unit', name: 'json-unit-assertj', version: '2.36.1'
-  testImplementation group: 'org.pitest', name: 'pitest', version: '1.11.7'
+  testImplementation group: 'net.javacrumbs.json-unit', name: 'json-unit-assertj', version: '3.4.1'
+  testImplementation group: 'org.pitest', name: 'pitest', version: '1.17.0'
   testImplementation group: 'info.solidsoft.gradle.pitest', name: 'gradle-pitest-plugin', version: pitest.pitestVersion.get()
   testImplementation group: 'org.codehaus.sonar-plugins', name: 'sonar-pitest-plugin', version: '0.5'
-  testImplementation group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: '2.35.0', {
+  testImplementation group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: '2.35.2', {
       exclude group: 'junit', module: 'junit'
   }
-  testImplementation group: 'com.typesafe', name: 'config', version: '1.4.2'
-  testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.9.2'
+  testImplementation group: 'com.typesafe', name: 'config', version: '1.4.3'
+  testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.11.0'
+  testRuntimeOnly group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.11.0'
   testImplementation group: 'org.apiguardian', name: 'apiguardian-api', version: '1.1.2'
 
   integrationTestImplementation(group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: '3.1.10') {
@@ -287,75 +287,14 @@ dependencies {
 dependencyManagement {
   dependencies {
 
-    dependency group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
-
-    dependency group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.20.0'
-    dependency group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.20.0'
-
-    //CVE-2021-40690
-     dependency group: 'org.apache.santuario', name: 'xmlsec', version: '3.0.1'
-
-    // CVE-2019-0232, CVE-2019-0199 - command line injections on windows
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.86') {
-      entry 'tomcat-embed-core'
-      entry 'tomcat-embed-el'
-      entry 'tomcat-embed-websocket'
-    }
-
-    //to remove CVE-2020-8908
-    dependencySet(group: 'com.google.guava', version: '32.1.0-jre') {
-      entry 'guava'
-    }
-
-    //CVE-2021-22112
-    dependencySet(group: 'org.springframework.security', version: '5.7.10') {
-      entry 'spring-security-crypto'
-    }
-
-    //CVE-2021-27807
-    dependencySet(group: 'org.apache.pdfbox', version: '2.0.27') {
-      entry 'pdfbox'
-    }
-
-    dependencySet(group: 'org.apache.xmlgraphics', version: '1.16') {
-      entry 'batik-all'
-    }
-
+    // CVE-2022-1471, CVE-2022-25857, CVE-2022-38749, CVE-2022-38751, CVE-2022-38752, CVE-2022-41854, CVE-2022-38750
     dependency group: 'org.yaml', name: 'snakeyaml', version: '2.0'
-
-//    //CVE-2021-22118
-//    dependencySet(group: 'org.springframework', version: '5.3.28') {
-//      entry 'spring-aop'
-//      entry 'spring-aspects'
-//      entry 'spring-beans'
-//      entry 'spring-context'
-//      entry 'spring-context-support'
-//      entry 'spring-core'
-//      entry 'spring-expression'
-//      entry 'spring-jcl'
-//      entry 'spring-jdbc'
-//      entry 'spring-orm'
-//      entry 'spring-tx'
-//      entry 'spring-web'
-//      entry 'spring-webmvc'
-//    }
-
-    //CVE-2021-27568
-    dependencySet(group: 'net.minidev', version: '2.4.10') {
-      entry 'json-smart'
-    }
-
-    dependencySet(group: 'net.minidev', version: '2.4.9') {
-      entry 'accessors-smart'
-    }
 
     imports {
       mavenBom "org.springframework.cloud:spring-cloud-dependencies:2021.0.8"
     }
-    //CVE-2021-28170
-    dependency group: 'org.glassfish', name: 'jakarta.el', version: '4.0.2'
 
-    //CVE-2020-36518, CVE-2022-42004
+    // CVE-2023-35116
     dependencySet(group: 'com.fasterxml.jackson.core', version: '2.17.2') {
         entry 'jackson-databind'
         entry 'jackson-core'
@@ -370,9 +309,6 @@ dependencyManagement {
       entry 'logback-core'
       entry 'logback-classic'
     }
-
-    // CVE-2023-34042
-    dependency group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.8.10'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -225,7 +225,7 @@ dependencies {
   implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
   implementation group: 'org.elasticsearch', name: 'elasticsearch', version: '7.17.9'
 
-  implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
+  implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.7.0'
 
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.0.1'
 
@@ -323,22 +323,22 @@ dependencyManagement {
 
     dependency group: 'org.yaml', name: 'snakeyaml', version: '2.0'
 
-    //CVE-2021-22118
-    dependencySet(group: 'org.springframework', version: '5.3.28') {
-      entry 'spring-aop'
-      entry 'spring-aspects'
-      entry 'spring-beans'
-      entry 'spring-context'
-      entry 'spring-context-support'
-      entry 'spring-core'
-      entry 'spring-expression'
-      entry 'spring-jcl'
-      entry 'spring-jdbc'
-      entry 'spring-orm'
-      entry 'spring-tx'
-      entry 'spring-web'
-      entry 'spring-webmvc'
-    }
+//    //CVE-2021-22118
+//    dependencySet(group: 'org.springframework', version: '5.3.28') {
+//      entry 'spring-aop'
+//      entry 'spring-aspects'
+//      entry 'spring-beans'
+//      entry 'spring-context'
+//      entry 'spring-context-support'
+//      entry 'spring-core'
+//      entry 'spring-expression'
+//      entry 'spring-jcl'
+//      entry 'spring-jdbc'
+//      entry 'spring-orm'
+//      entry 'spring-tx'
+//      entry 'spring-web'
+//      entry 'spring-webmvc'
+//    }
 
     //CVE-2021-27568
     dependencySet(group: 'net.minidev', version: '2.4.10') {

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 plugins {
   id 'application'
   id 'pmd'
-  id 'org.sonarqube' version '4.0.0.2929'
+  id 'org.sonarqube' version '4.3.0.3225'
   id 'jacoco'
   id 'info.solidsoft.pitest' version '1.9.11'
   id 'io.spring.dependency-management' version '1.1.6'
   id 'org.springframework.boot' version '2.7.18'
   id 'uk.gov.hmcts.java' version '0.12.63'
   id 'org.owasp.dependencycheck' version '10.0.4'
-  id 'com.github.ben-manes.versions' version '0.46.0'
+  id 'com.github.ben-manes.versions' version '0.51.0'
 }
 
 group = 'uk.gov.hmcts.reform'
@@ -234,7 +234,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.3'
 
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: 'cb61d43'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: 'e80ef5c'
 
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.4'
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.4'

--- a/build.gradle
+++ b/build.gradle
@@ -234,7 +234,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.3'
 
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: 'b0832a7'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '304cc79'
 
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.4'
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.4'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'org.sonarqube' version '4.0.0.2929'
   id 'jacoco'
   id 'info.solidsoft.pitest' version '1.9.11'
-  id 'io.spring.dependency-management' version '1.0.12.RELEASE'
+  id 'io.spring.dependency-management' version '1.1.6'
   id 'org.springframework.boot' version '2.7.18'
   id 'uk.gov.hmcts.java' version '0.12.12'
   id 'org.owasp.dependencycheck' version '10.0.3'

--- a/build.gradle
+++ b/build.gradle
@@ -234,7 +234,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.3'
 
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: 'e80ef5c'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '102fb28'
 
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.6.4'
   implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.4'

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -174,6 +174,7 @@
     <module name="AbbreviationAsWordInName">
       <property name="ignoreFinal" value="false"/>
       <property name="allowedAbbreviationLength" value="1"/>
+      <property name="allowedAbbreviations" value="API"/>
     </module>
     <module name="OverloadMethodsDeclarationOrder"/>
     <module name="VariableDeclarationUsageDistance"/>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2024-10-01">
-    <cve>CVE-2023-35116</cve>
-    <cve>CVE-2023-1370</cve>
-  </suppress>
+
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2024-11-01">
+  <suppress until="2024-12-01">
     <cve>CVE-2024-45772</cve>
+    <cve>CVE-2024-38820</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,2 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd"/>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress until="2024-11-01">
+    <cve>CVE-2024-45772</cve>
+  </suppress>
+</suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,4 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd"/>
-
-</suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-
+  <suppress until="2024-09-01">
+    <cve>CVE-2023-1370</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,6 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2024-10-01">
-    <cve>CVE-2023-1370</cve>
-  </suppress>
-</suppressions>
+<?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd"/>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2024-09-01">
+  <suppress until="2024-10-01">
     <cve>CVE-2023-1370</cve>
   </suppress>
 </suppressions>

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscs/BaseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscs/BaseTest.java
@@ -23,7 +23,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.util.SocketUtils;
+import org.springframework.test.util.TestSocketUtils;
 import uk.gov.hmcts.reform.authorisation.validators.AuthTokenValidator;
 import uk.gov.hmcts.reform.sscs.ccd.service.SscsQueryBuilder;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
@@ -65,7 +65,7 @@ public abstract class BaseTest {
     protected IdamTokens idamTokens;
 
     static {
-        wiremockPort = SocketUtils.findAvailableTcpPort();
+        wiremockPort = TestSocketUtils.findAvailableTcpPort();
         System.setProperty("core_case_data.api.url", "http://localhost:" + wiremockPort);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/BulkScanApplication.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/BulkScanApplication.java
@@ -7,7 +7,6 @@ import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_ENUMS_US
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -66,7 +65,7 @@ public class BulkScanApplication {
 
         ObjectMapper mapper = objectMapperBuilder.createXmlMapper(false).build();
         mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
-        mapper.registerModule(new JavaTimeModule());
+        mapper.findAndRegisterModules();
         return mapper;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/bulkscancore/domain/CaseResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/bulkscancore/domain/CaseResponse.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.sscs.bulkscancore.domain;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Map;
 import lombok.Builder;
@@ -10,13 +10,13 @@ import uk.gov.hmcts.reform.sscs.domain.validation.ValidationStatus;
 @Data
 @Builder
 public class CaseResponse {
-    @ApiModelProperty(value = "Warning messages")
+    @Schema(description = "Warning messages")
     private List<String> warnings;
-    @ApiModelProperty(value = "Transformed case")
+    @Schema(description = "Transformed case")
     private Map<String, Object> transformedCase;
-    @ApiModelProperty(value = "Error messages")
+    @Schema(description = "Error messages")
     private List<String> errors;
-    @ApiModelProperty(value = "Validation status")
+    @Schema(description = "Validation status")
     private ValidationStatus status;
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/config/SwaggerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/config/SwaggerConfiguration.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.sscs.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
@@ -9,6 +10,7 @@ import springfox.documentation.spring.web.plugins.Docket;
 import uk.gov.hmcts.reform.sscs.BulkScanApplication;
 
 @Configuration
+@EnableWebMvc
 public class SwaggerConfiguration {
 
     @Bean

--- a/src/main/java/uk/gov/hmcts/reform/sscs/config/SwaggerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/config/SwaggerConfiguration.java
@@ -6,11 +6,9 @@ import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 import uk.gov.hmcts.reform.sscs.BulkScanApplication;
 
 @Configuration
-@EnableSwagger2
 public class SwaggerConfiguration {
 
     @Bean

--- a/src/main/java/uk/gov/hmcts/reform/sscs/config/SwaggerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/config/SwaggerConfiguration.java
@@ -1,26 +1,29 @@
 package uk.gov.hmcts.reform.sscs.config;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import uk.gov.hmcts.reform.sscs.BulkScanApplication;
 
 @Configuration
-@EnableWebMvc
 public class SwaggerConfiguration {
 
+    @Value("${spring.application.name}")
+    private String applicationName;
+
     @Bean
-    public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
-            .useDefaultResponseMessages(false)
-            .select()
-            .apis(RequestHandlerSelectors.basePackage(BulkScanApplication.class.getPackage().getName() + ".controllers"))
-            .paths(PathSelectors.any())
-            .build();
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title(applicationName)
+                .description("SSCS Bulk Scan API")
+                .version("v1.0.0")
+                .contact(new Contact()
+                    .name("SSCS")
+                    .url("http://sscs.net/")
+                    .email("sscs@hmcts.net")));
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/controllers/CcdCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/controllers/CcdCallbackController.java
@@ -2,9 +2,11 @@ package uk.gov.hmcts.reform.sscs.controllers;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -46,13 +48,14 @@ public class CcdCallbackController {
 
     @PostMapping(path = "/validate-record",
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Handles callback from SSCS to check case meets validation to change state to appeal created")
+    @Operation(summary = "Handles callback from SSCS to check case meets validation to change state to appeal created")
     @ApiResponses(value = {
-        @ApiResponse(code = 200,
-            message = "Callback was processed successfully or in case of an error message is attached to the case",
-            response = CallbackResponse.class),
-        @ApiResponse(code = 400, message = "Bad Request"),
-        @ApiResponse(code = 500, message = "Internal Server Error")
+        @ApiResponse(responseCode = "200",
+            description = "Callback was processed successfully or in case of an error message is attached to the case",
+            content = {
+                @Content(mediaType = "application/json", schema = @Schema(implementation = CallbackResponse.class)) }),
+        @ApiResponse(responseCode = "400", description = "Bad Request"),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error")
     })
     public ResponseEntity<PreSubmitCallbackResponse<SscsCaseData>> handleValidationCallback(
         @RequestHeader(value = "Authorization") String userAuthToken,

--- a/src/main/java/uk/gov/hmcts/reform/sscs/controllers/OcrValidationController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/controllers/OcrValidationController.java
@@ -3,9 +3,11 @@ package uk.gov.hmcts.reform.sscs.controllers;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.http.ResponseEntity.ok;
 
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import javax.validation.Valid;
@@ -46,12 +48,12 @@ public class OcrValidationController {
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE
     )
-    @ApiOperation("Validates OCR form data based on form type")
+    @Operation(summary = "Validates OCR form data based on form type")
     @ApiResponses({
-        @ApiResponse(code = 200, response = OcrValidationResponse.class,
-            message = "Validation executed successfully"),
-        @ApiResponse(code = 401, message = "Provided S2S token is missing or invalid"),
-        @ApiResponse(code = 403, message = "S2S token is not authorized to use the service")
+        @ApiResponse(responseCode = "200", description = "Validation executed successfully", content = {
+            @Content(mediaType = "application/json", schema = @Schema(implementation = OcrValidationResponse.class)) }),
+        @ApiResponse(responseCode = "401", description = "Provided S2S token is missing or invalid"),
+        @ApiResponse(responseCode = "403", description = "S2S token is not authorized to use the service")
     })
     public ResponseEntity<OcrValidationResponse> validateOcrData(
         @RequestHeader(name = "ServiceAuthorization", required = false) String serviceAuthHeader,

--- a/src/main/java/uk/gov/hmcts/reform/sscs/domain/validation/OcrDataValidationRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/domain/validation/OcrDataValidationRequest.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.sscs.domain.validation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import javax.validation.constraints.NotEmpty;
 import lombok.Data;
@@ -10,7 +10,7 @@ import uk.gov.hmcts.reform.sscs.bulkscancore.domain.OcrDataField;
 @Data
 public class OcrDataValidationRequest {
 
-    @ApiModelProperty(value = "List of ocr data fields to be validated.", required = true)
+    @Schema(description = "List of ocr data fields to be validated.", required = true)
     @NotEmpty
     private final List<OcrDataField> ocrDataFields;
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,9 @@ management:
     web:
       base-path: /
 
+springdoc:
+  packagesToScan: uk.gov.hmcts.reform.sscs.controllers
+
 spring:
   application:
     name: SscsBulkScan


### PR DESCRIPTION
### Jira link

See [SSCSCI-995](https://tools.hmcts.net/jira/browse/SSCSCI-995)

### Change description

- Bumped jackson to latest version to fix CVE-2023-35116
- Bumped sscs-common
- Upgraded spring to 2.7.18
- Replaced [SpringFox](https://springfox.github.io/springfox/) with [springdoc](https://springdoc.org/)
- Upgraded junit to 5.11.0

